### PR TITLE
BUG: Fix MacOS preprocessing parallel jobs issue

### DIFF
--- a/src/napari_dmc_brainmap/preprocessing/preprocessing.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing.py
@@ -5,6 +5,7 @@ DMC-BrainMap widget for preprocessing of .tif files.
 """
 
 import os
+import platform
 from pathlib import Path
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QPushButton, QWidget, QVBoxLayout, QMessageBox, QProgressBar
@@ -53,6 +54,9 @@ def do_preprocessing(
     if "operations" in preprocessing_params.keys():
         resolution_tuple = tuple(resolution) if 'sharpy_track' in preprocessing_params['operations'] else False
         num_cores = os.cpu_count()
+        # overwrite parallelization to 1 if detects Darwin OS
+        if platform.system() == 'Darwin':
+            num_cores = 1
         chunk_img_list = chunk_list(img_list, chunk_size=num_cores)
         progress_value = 0
         progress_step = 100 / len(chunk_img_list)

--- a/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
@@ -86,12 +86,10 @@ def load_stitched_images(input_path: Union[str, Path], chan: str, image: str) ->
     im_fn = input_path.joinpath('stitched', chan, f"{image}_stitched.tif")
     if im_fn.exists():
         return cv2.imread(str(im_fn), cv2.IMREAD_ANYDEPTH)  # Load in grayscale mode
-    show_info(
-        f"WARNING: No stitched images named {image}_stitched.tif found in {im_fn}. "
+    raise FileNotFoundError(f"WARNING: No stitched images named {image}_stitched.tif found in {im_fn}. "
         "Do padding on images if _stitched.tif suffix is missing."
         "Ensure images have the '_stitched.tif' suffix and are single-channel 16-bit."
-    )
-    return False
+        "Please restart the preprocessing widget to continue.")
 
 
 def downsample_and_adjust_contrast(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Force single-core processing on macOS

- Raise error when stitched image missing

- Import `platform` for OS detection

- Remove fallback warning and false return


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preprocessing.py</strong><dd><code>Single-core processing on macOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/napari_dmc_brainmap/preprocessing/preprocessing.py

<li>Imported <code>platform</code> for OS checks<br> <li> Force <code>num_cores = 1</code> on Darwin systems


</details>


  </td>
  <td><a href="https://github.com/hejDMC/napari-dmc-brainmap/pull/11/files#diff-c54f5b76a3adf05e61ae5d9b0048b6cd098f47e4c1df1f1bb53ff6d9e77d3c1f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preprocessing_tools.py</strong><dd><code>Raise error for missing stitched images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py

<li>Replace warning with <code>FileNotFoundError</code> on missing images<br> <li> Remove <code>show_info</code> call and <code>False</code> return fallback


</details>


  </td>
  <td><a href="https://github.com/hejDMC/napari-dmc-brainmap/pull/11/files#diff-178f9d870d4c210a408732d50d29c708cba1e160678e2d1494f5234dc8e4992a">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>