### PR TITLE
Filter out macOS '._' metadata files from all file/directory listings

### DIFF
--- a/src/napari_dmc_brainmap/padding/padding.py
+++ b/src/napari_dmc_brainmap/padding/padding.py
@@ -56,7 +56,7 @@ def do_padding(input_path: Path,
     progress_step = 100 / image_count
 
     for chan in channels:
-        tif_files = list(input_path.joinpath(pad_folder, chan).glob("*.tif"))
+        tif_files = [f for f in input_path.joinpath(pad_folder, chan).glob("*.tif") if not f.name.startswith('._')]
         try:
             if not tif_files[0].name.endswith("_stitched.tif"):
                 rename_image_files(tif_files, input_path, pad_folder, chan)
@@ -100,7 +100,7 @@ def count_images(input_path: Path, pad_folder: str, channels: List[str]) -> int:
     Returns:
         int: The total count of images in the specified channels.
     """
-    image_count = sum(len(list(input_path.joinpath(pad_folder, chan).glob("*.tif"))) for chan in channels)
+    image_count = sum(len([f for f in input_path.joinpath(pad_folder, chan).glob("*.tif") if not f.name.startswith('._')]) for chan in channels)
     return max(image_count, 1)
 
 

--- a/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/view/RegistrationViewer.py
+++ b/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/view/RegistrationViewer.py
@@ -108,7 +108,7 @@ class RegistrationViewer(QMainWindow):
         if (self.status.folderPath is None) | (self.status.folderPath == ''):
             pass
         else:
-            self.status.imgFileName = natsorted([f.parts[-1] for f in self.status.folderPath.glob('*.tif')])
+            self.status.imgFileName = natsorted([f.parts[-1] for f in self.status.folderPath.glob('*.tif') if not f.name.startswith('._')])
             self.status.sliceNum = len(self.status.imgFileName)
             if self.status.sliceNum == 0:
                 pass

--- a/src/napari_dmc_brainmap/results/results.py
+++ b/src/napari_dmc_brainmap/results/results.py
@@ -608,7 +608,7 @@ class ResultsWidget(QWidget):
         if not check_input_path(input_path):
             return
         if self.merge.animal_list.value == ':':
-            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir()]
+            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir() and not f.name.startswith('._')]
         else:
             animal_list = split_to_list(self.merge.animal_list.value)
         channels = self.merge.channels.value

--- a/src/napari_dmc_brainmap/results/results_helpers/results_creator.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/results_creator.py
@@ -117,7 +117,7 @@ class ResultsCreator:
             List[str]: List of segmentation channels.
         """
         seg_super_dir = get_info(self.input_path, 'segmentation', seg_type=self.seg_type, only_dir=True)
-        return natsorted([f.parts[-1] for f in seg_super_dir.iterdir() if f.is_dir()])
+        return natsorted([f.parts[-1] for f in seg_super_dir.iterdir() if f.is_dir() and not f.name.startswith('._')])
 
     def _get_segment_list(self, chan: str) -> List[str]:
         """

--- a/src/napari_dmc_brainmap/results/results_helpers/tract_calculator.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/tract_calculator.py
@@ -43,7 +43,7 @@ class TractCalculator:
         """
         Calculate and save probe tracts based on segmentation and atlas data.
         """
-        probes_list = natsorted([p.parts[-1] for p in self.results_dir.iterdir() if p.is_dir()])
+        probes_list = natsorted([p.parts[-1] for p in self.results_dir.iterdir() if p.is_dir() and not p.name.startswith('._')])
         probes_dict = {}
         ax_map = {'ap': 'AP', 'si': 'DV', 'rl': 'ML'}
         show_info("calculating probe tract for...")
@@ -81,7 +81,7 @@ class TractCalculator:
             pd.DataFrame: Dataframe containing probe data.
         """
         data_dir = self.results_dir.joinpath(probe)
-        data_fn = list(data_dir.glob('*csv'))[0]
+        data_fn = [f for f in data_dir.glob('*csv') if not f.name.startswith('._')][0]
         probe_df = pd.read_csv(data_fn)
         name_dict = {'ap': 'ap_coords', 'si': 'dv_coords', 'rl': 'ml_coords'}
         for atlas_ax, abc_name in zip(self.atlas.space.axes_description, self.ABC_LIST):

--- a/src/napari_dmc_brainmap/segment/processing/centroid_finder.py
+++ b/src/napari_dmc_brainmap/segment/processing/centroid_finder.py
@@ -77,7 +77,7 @@ class CentroidFinder:
         total_images = 0
         for chan in self.channels:
             mask_dir = get_info(self.input_path, self.mask_folder, seg_type=self.mask_type, channel=chan, only_dir=True)
-            total_images += len([im for im in mask_dir.glob('*.tiff')])
+            total_images += len([im for im in mask_dir.glob('*.tiff') if not im.name.startswith('._')])
 
         processed_images = 0
         for chan in self.channels:
@@ -86,7 +86,7 @@ class CentroidFinder:
             output_dir = get_info(self.input_path, self.output_folder, seg_type=self.mask_type, channel=chan, create_dir=True,
                                   only_dir=True)
 
-            mask_images = natsorted([im for im in mask_dir.glob('*.tiff')])
+            mask_images = natsorted([im for im in mask_dir.glob('*.tiff') if not im.name.startswith('._')])
             for mask_image_path in mask_images:
                 print(f"Processing mask image: {mask_image_path}")
                 save_path = output_dir.joinpath(f"{mask_image_path.stem}_{self.mask_type}.csv")
@@ -113,7 +113,7 @@ class CentroidFinder:
                 mask_dir = get_info(self.input_path, self.mask_folder, seg_type=self.mask_type, channel=chan, only_dir=True)
                 output_dir = get_info(self.input_path, self.output_folder, seg_type=self.mask_type, channel=chan, create_dir=True, only_dir=True)
 
-                mask_images = natsorted([im for im in mask_dir.glob('*.tiff')])
+                mask_images = natsorted([im for im in mask_dir.glob('*.tiff') if not im.name.startswith('._')])
                 for mask_image_path in mask_images:
                     save_path = output_dir.joinpath(f"{mask_image_path.stem}_{self.mask_type}.csv")
                     # Submit each image processing task to the executor

--- a/src/napari_dmc_brainmap/segment/segment.py
+++ b/src/napari_dmc_brainmap/segment/segment.py
@@ -90,7 +90,7 @@ def get_path_to_im(
         seg_im_dir, seg_im_list, seg_im_suffix = get_info(input_path, 'single_channel', channel=chan)
     else:
         seg_im_dir, seg_im_list, seg_im_suffix = get_info(input_path, 'rgb')
-    im = natsorted([f.parts[-1] for f in seg_im_dir.glob('*.tif')])[
+    im = natsorted([f.parts[-1] for f in seg_im_dir.glob('*.tif') if not f.name.startswith('._')])[
         image_idx
     ]  # this detour due to some weird bug, list of paths was only sorted, not natsorted
     path_to_im = seg_im_dir.joinpath(im)

--- a/src/napari_dmc_brainmap/stitching/stitching.py
+++ b/src/napari_dmc_brainmap/stitching/stitching.py
@@ -50,7 +50,7 @@ def do_stitching(input_path: Path,
     animal_id = get_animal_id(input_path)
     resolution = tuple(params_dict['atlas_info']['resolution'])
     data_dir = input_path.joinpath('raw')
-    objs = natsorted([o.parts[-1] for o in data_dir.iterdir() if o.is_dir()])
+    objs = natsorted([o.parts[-1] for o in data_dir.iterdir() if o.is_dir() and not o.name.startswith('._')])
 
     if not objs:
         show_info('No object slides under raw-data folder!')
@@ -100,10 +100,10 @@ def process_stitch_folder(input_path: Path,
         overlap (int, optional): Overlap for stitching tiles. Defaults to 205.
     """
     in_chan = in_obj.joinpath(f)
-    section_list = natsorted([s.parts[-1] for s in in_chan.iterdir() if s.is_dir()])
+    section_list = natsorted([s.parts[-1] for s in in_chan.iterdir() if s.is_dir() and not s.name.startswith('._')])
     section_list_new = [f"{animal_id}_{obj}_{str(k + 1)}" for k, ss in enumerate(section_list)]
     [in_chan.joinpath(old).rename(in_chan.joinpath(new)) for old, new in zip(section_list, section_list_new)]
-    section_dirs = natsorted([s for s in in_chan.iterdir() if s.is_dir()])
+    section_dirs = natsorted([s for s in in_chan.iterdir() if s.is_dir() and not s.name.startswith('._')])
 
     for section in section_dirs:
         stitched_path = stitch_dir.joinpath(f'{section.parts[-1]}_stitched.tif')
@@ -145,7 +145,7 @@ def process_stitch_stack(input_path: Path,
         overlap (int, optional): Overlap for stitching tiles. Defaults to 205.
     """
     in_chan = in_obj.joinpath(f'{obj}_{f}_1')
-    stack = natsorted([im.parts[-1] for im in in_chan.glob('*.tif')])
+    stack = natsorted([im.parts[-1] for im in in_chan.glob('*.tif') if not im.name.startswith('._')])
     whole_stack = load_tile_stack(in_chan, stack)
 
     meta_json_where = in_obj.joinpath(f'{obj}_meta_1', 'regions_pos.json')

--- a/src/napari_dmc_brainmap/stitching/stitching_tools.py
+++ b/src/napari_dmc_brainmap/stitching/stitching_tools.py
@@ -18,7 +18,7 @@ def load_meta(section_dir: Path) -> Dict:
     Returns:
         Dict: Metadata as a dictionary.
     """
-    path_to_tiff = section_dir.joinpath([f.parts[-1] for f in section_dir.glob('*.tif')][0])
+    path_to_tiff = section_dir.joinpath([f.parts[-1] for f in section_dir.glob('*.tif') if not f.name.startswith('._')][0])
     with tifffile.TiffFile(path_to_tiff) as tif:
         meta_data = json.loads(tif.imagej_metadata['Info'])
     return meta_data

--- a/src/napari_dmc_brainmap/utils/data_loader.py
+++ b/src/napari_dmc_brainmap/utils/data_loader.py
@@ -47,7 +47,7 @@ class DataLoader:
         for animal_id in self.animal_list:
             if self.data_type in ["optic_fiber", "neuropixels_probe"]:
                 seg_super_dir = get_info(self.input_path.joinpath(animal_id), 'results', seg_type=self.data_type, only_dir=True)
-                self.channels = natsorted([f.parts[-1] for f in seg_super_dir.iterdir() if f.is_dir()])
+                self.channels = natsorted([f.parts[-1] for f in seg_super_dir.iterdir() if f.is_dir() and not f.name.startswith('._')])
 
             params = self._load_params(self.input_path.joinpath(animal_id, 'params.json'))
 

--- a/src/napari_dmc_brainmap/utils/path_utils.py
+++ b/src/napari_dmc_brainmap/utils/path_utils.py
@@ -64,7 +64,7 @@ def get_data_list(data_dir: Path, pattern: str) -> List[str]:
         List[str]: A sorted list of file names.
     """
     if data_dir.exists():
-        return natsorted([f.name for f in data_dir.glob(pattern)])
+        return natsorted([f.name for f in data_dir.glob(pattern) if not f.name.startswith('._')])
     return []
 
 

--- a/src/napari_dmc_brainmap/visualization/visualization.py
+++ b/src/napari_dmc_brainmap/visualization/visualization.py
@@ -820,7 +820,7 @@ class VisualizationWidget(QWidget):
             if not check_input_path(save_path):
                 return
         if self.header.animal_list.value == ':':
-            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir()]
+            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir() and not f.name.startswith('._')]
         else:
             animal_list = split_to_list(self.header.animal_list.value)
         channels = self.header.channels.value
@@ -916,7 +916,7 @@ class VisualizationWidget(QWidget):
             if not check_input_path(save_path):
                 return
         if self.header.animal_list.value == ':':
-            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir()]
+            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir() and not f.name.startswith('._')]
         else:
             animal_list = split_to_list(self.header.animal_list.value)
         channels = self.header.channels.value
@@ -1019,7 +1019,7 @@ class VisualizationWidget(QWidget):
             if not check_input_path(save_path):
                 return
         if self.header.animal_list.value == ':':
-            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir()]
+            animal_list = [f.parts[-1] for f in input_path.iterdir() if f.is_dir() and not f.name.startswith('._')]
         else:
             animal_list = split_to_list(self.header.animal_list.value)
         channels = self.header.channels.value


### PR DESCRIPTION
Fixes #13. macOS creates '._' prefixed metadata files on non-HFS+ filesystems (e.g. USB drives), which were being picked up by glob/iterdir calls and causing read errors, corrupted suffix detection, and wrong file selection.