### PR TITLE
Fix NPX probe segmentation on single-channel images

### DIFF
--- a/src/napari_dmc_brainmap/results/results_helpers/results_creator.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/results_creator.py
@@ -62,6 +62,7 @@ class ResultsCreator:
         """
         self.s = self._initialize_registration()
         if self.seg_type in ["optic_fiber", "neuropixels_probe"]:
+            self.image_channels = self.channels  # preserve original image channels for folder lookup
             self.channels = self._get_segmentation_channels()
         elif self.seg_type == "single_cell":
             self.channels = self._get_segmentation_channels()
@@ -147,6 +148,9 @@ class ResultsCreator:
         regi_dir, regi_im_list, regi_suffix = get_info(self.input_path, 'sharpy_track', channel=self.regi_chan)
         if self.seg_folder == 'rgb':
             seg_im_dir, seg_im_list, seg_im_suffix = get_info(self.input_path, self.seg_folder)
+        elif self.seg_type in ["optic_fiber", "neuropixels_probe"]:
+            seg_im_dir, seg_im_list, seg_im_suffix = get_info(self.input_path, self.seg_folder,
+                                                               channel=self.image_channels[0])
         else:
             seg_im_dir, seg_im_list, seg_im_suffix = get_info(self.input_path, self.seg_folder, channel=chan)
         segment_dir, segment_list, segment_suffix = get_info(self.input_path, 'segmentation', channel=chan, seg_type=self.seg_type)

--- a/src/napari_dmc_brainmap/segment/segment.py
+++ b/src/napari_dmc_brainmap/segment/segment.py
@@ -666,16 +666,20 @@ class SegmentWidget(QWidget):
         self.viewer.add_image(im_loaded, name=f'{chan} channel', colormap=cmap_disp[chan], opacity=0.5)
         self.viewer.layers[f'{chan} channel'].contrast_limits = contrast_dict[chan]
 
-    def _load_preseg_object(self, input_path: Path, chan: str, image_idx: int, seg_type: str, single_channel: bool) -> np.ndarray:
+    def _load_preseg_object(self, input_path: Path, chan: str, image_idx: int, seg_type: str, single_channel: bool,
+                            image_chan: str = None) -> np.ndarray:
         """
         Load pre-segmented data for a specific image and channel.
 
         Parameters:
             input_path (Path): Path to the input directory.
-            chan (str): The channel being processed.
+            chan (str): The channel or segment ID being processed (e.g., 'cy3' for cells, 'npx_0' for probes).
             image_idx (int): The index of the image being segmented.
             seg_type (str): The type of segmentation.
             single_channel (bool): Whether to process single-channel images.
+            image_chan (str, optional): The actual image channel name for locating the source image.
+                When None, defaults to chan. Used for probe segmentation where chan is a probe ID
+                (e.g., 'npx_0') but the image is stored under the actual channel name.
 
         Returns:
             np.ndarray: Array of pre-segmented data.
@@ -683,8 +687,9 @@ class SegmentWidget(QWidget):
         pre_seg_folder = self.load_preseg.pre_seg_folder.value
         pre_seg_dir, pre_seg_list, pre_seg_suffix = get_info(input_path, pre_seg_folder, seg_type=seg_type,
                                                              channel=chan)
+        im_chan = image_chan if image_chan else chan
         if single_channel:
-            im_name = get_path_to_im(input_path, image_idx, single_channel=single_channel, chan=chan, pre_seg=True)
+            im_name = get_path_to_im(input_path, image_idx, single_channel=single_channel, chan=im_chan, pre_seg=True)
         else:
             im_name = get_path_to_im(input_path, image_idx, pre_seg=True)  # name of image that will be loaded
         fn_to_load = [d for d in pre_seg_list if d.startswith(f'{im_name}_')]
@@ -756,7 +761,8 @@ class SegmentWidget(QWidget):
                     p_color = random.choice(list(mcolors.CSS4_COLORS.keys()))
                 p_id = f'{seg_type}_{str(i)}'
                 if self.load_preseg.load_bool.value:
-                    pre_seg_data = self._load_preseg_object(input_path, p_id, image_idx, seg_type, single_channel)
+                    pre_seg_data = self._load_preseg_object(input_path, p_id, image_idx, seg_type, single_channel,
+                                                            image_chan=channels[0] if single_channel else None)
                     self.viewer.add_points(pre_seg_data, size=int(self.segment.point_size.value), name=p_id,
                                            face_color=p_color)
                 else:

--- a/src/napari_dmc_brainmap/segment/segment.py
+++ b/src/napari_dmc_brainmap/segment/segment.py
@@ -15,7 +15,7 @@ import matplotlib.colors as mcolors
 import time
 from napari.utils.notifications import show_info
 from typing import Dict, Union, List
-from napari_dmc_brainmap.utils.path_utils import get_image_list, get_info
+from napari_dmc_brainmap.utils.path_utils import get_image_list, get_info, get_data_list
 from napari_dmc_brainmap.utils.general_utils import split_to_list
 from napari_dmc_brainmap.utils.params_utils import load_params
 from napari_dmc_brainmap.utils.gui_utils import ProgressBar, check_input_path
@@ -685,8 +685,8 @@ class SegmentWidget(QWidget):
             np.ndarray: Array of pre-segmented data.
         """
         pre_seg_folder = self.load_preseg.pre_seg_folder.value
-        pre_seg_dir, pre_seg_list, pre_seg_suffix = get_info(input_path, pre_seg_folder, seg_type=seg_type,
-                                                             channel=chan)
+        pre_seg_dir = get_info(input_path, pre_seg_folder, seg_type=seg_type, channel=chan, only_dir=True)
+        pre_seg_list = get_data_list(pre_seg_dir, '*.csv')
         im_chan = image_chan if image_chan else chan
         if single_channel:
             im_name = get_path_to_im(input_path, image_idx, single_channel=single_channel, chan=im_chan, pre_seg=True)


### PR DESCRIPTION
## Summary
- Fix probe segmentation reload failing on single-channel images: probe IDs (e.g., `npx_0`) were incorrectly used as image channel names when constructing file paths, causing `IndexError` in single-channel mode
- Fix multi-probe pre-segmentation reload causing Qt event loop error: replaced `get_info()` with `get_info(only_dir=True)` + `get_data_list()` to avoid `find_common_suffix()` calling `input()` on the Qt main thread
- Fix probe results creation failing on single-channel images: preserved original image channels before overwriting with probe IDs, so `_process_channel()` uses the correct channel name for image folder lookup

All three bugs share the same root cause: probe IDs being used where image channel names are expected, which only manifests in single-channel mode since RGB mode doesn't use channel subfolders.

Verified against all segmentation types (cells, injection_site, projections, optic_fiber, neuropixels_probe, genes, single_cell, hcr) — no regressions.

## Test plan
- [x] Tested by user with single-channel neuropixels probe segmentation reload (single probe)
- [x] Tested by user with single-channel neuropixels probe segmentation reload (multiple probes)
- [x] Tested by user with single-channel neuropixels probe results creation
- [x] Tested by user: probe viewer and section plotting work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)