### PR TITLE
 Fix suggestion: save segmentation mask image in segment_cells()

### DIFF
--- a/src/napari_dmc_brainmap/segment/processing/presegmentation_tools.py
+++ b/src/napari_dmc_brainmap/segment/processing/presegmentation_tools.py
@@ -340,6 +340,7 @@ class CellsSegmenter(PreSegmenter):
         # csv_to_save = pd.DataFrame({'Position Y': idx[0], 'Position X': idx[1]})
         csv_to_save = pd.DataFrame(seg_cells, columns=["Position Y", "Position X"])
         self.save_to_csv(csv_to_save, save_path)
+        cv2.imwrite(str(mask_save_fn), segmented_image)
 
         # Create a binary image with only centroid points for further visualization
         # centroid_binary = np.zeros(segmented_image.shape, dtype='uint8')


### PR DESCRIPTION
The segment_cells() method in presegmentation_tools.py receives mask_save_fn as a parameter but never writes the segmentation mask to disk. The save_mask_image() method exists on the class but is never called, and the cv2.imwrite block at the bottom of the method is commented out. This causes the segmentation_masks folder to be created but remain empty after presegmentation.
This one-line fix in line 343 adds cv2.imwrite(str(mask_save_fn), segmented_image) after the CSV is saved, so the binary mask is written alongside the centroid coordinates.