### PR TITLE
Release 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napari-dmc-brainmap"
-version = "0.1.7b16"
+version = "0.1.8"
 description = "DMC-BrainMap is an end-to-end tool for multi-feature brain mapping across species"
 readme = "README.md"
 requires-python = "==3.10.*"
@@ -10,7 +10,7 @@ authors = [
     { name = "Felix Jung", email = "jung.neurosc@gmail.com" },
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: napari",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -131,7 +131,7 @@ def test_split_to_list():
 
 
 
-def test_get_bregma():
+def test_get_bregma(monkeypatch):
     # Test case 1: Known atlas ID
     atlas_id = "allen_mouse_10um"
     expected_bregma = [540, 0, 570]
@@ -149,6 +149,15 @@ def test_get_bregma():
 
     # Test case 4: Unknown atlas ID
     atlas_id = "unknown_atlas"
+
+    def raise_invalid_atlas(requested_atlas_id):
+        assert requested_atlas_id == atlas_id
+        raise ValueError(f"{requested_atlas_id} is not a valid atlas name")
+
+    monkeypatch.setattr(
+        "napari_dmc_brainmap.utils.atlas_utils.BrainGlobeAtlas",
+        raise_invalid_atlas,
+    )
     with pytest.raises(ValueError, match="not a valid atlas name"):
         get_bregma(atlas_id)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1964,7 +1964,7 @@ wheels = [
 
 [[package]]
 name = "napari-dmc-brainmap"
-version = "0.1.7b16"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aicsimageio" },


### PR DESCRIPTION
## Summary

- bump `napari-dmc-brainmap` from `0.1.7b16` to the first stable `0.1.8` release
- update the Trove classifier from Beta to Production/Stable
- refresh the project version recorded in `uv.lock`
- isolate the invalid-atlas unit test from the live BrainGlobe configuration service

## Validation

- lightweight tox suite: 69 passed
- full dependency tox suite: 69 passed
- GitHub Actions passes on Windows, Ubuntu, and macOS
- wheel and source distribution build successfully
- Twine and wheel-content checks pass
- clean wheel install reports version 0.1.8 and registers the napari manifest entry point
- base wheel installation does not install optional PyTorch
- strict Sphinx documentation build passes
- napari plugin manifest validates
- `uv lock --check` and `git diff --check` pass

## Release safety

No tag, PyPI upload, or GitHub Release is created by this PR. Release artifacts will be rebuilt from the exact merged `main` commit before publication.