### PR TITLE
Declare direct joblib and superqt dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "brainglobe-atlasapi==3.0.0rc1",
     "distinctipy==1.3.4",
     "imagecodecs==2025.3.30",
+    "joblib==1.5.3",
     "magicgui==0.8.1",
     "matplotlib==3.10.9",
     "mergedeep==1.3.4",
@@ -44,6 +45,7 @@ dependencies = [
     "seaborn==0.12.2",
     "shapely==2.1.2",
     "scipy==1.17.1",
+    "superqt==0.8.2",
     "tifffile==2023.2.28",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
 deps =
     brainglobe-atlasapi==3.0.0rc1
     distinctipy==1.3.4
+    joblib==1.5.3
     magicgui==0.8.1
     matplotlib==3.10.9
     mergedeep==1.3.4
@@ -43,6 +44,7 @@ deps =
     seaborn==0.12.2
     shapely==2.1.2
     scipy==1.17.1
+    superqt==0.8.2
     tifffile==2023.2.28
 commands =
     pytest -v --color=yes --cov=napari_dmc_brainmap --cov-report=xml

--- a/uv.lock
+++ b/uv.lock
@@ -1630,6 +1630,7 @@ dependencies = [
     { name = "brainglobe-atlasapi", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "distinctipy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "imagecodecs", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "joblib", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "magicgui", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "matplotlib", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "mergedeep", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
@@ -1646,6 +1647,7 @@ dependencies = [
     { name = "scipy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "seaborn", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "shapely", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "superqt", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "tifffile", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 
@@ -1669,6 +1671,7 @@ requires-dist = [
     { name = "brainglobe-atlasapi", specifier = "==3.0.0rc1" },
     { name = "distinctipy", specifier = "==1.3.4" },
     { name = "imagecodecs", specifier = "==2025.3.30" },
+    { name = "joblib", specifier = "==1.5.3" },
     { name = "magicgui", specifier = "==0.8.1" },
     { name = "matplotlib", specifier = "==3.10.9" },
     { name = "mergedeep", specifier = "==1.3.4" },
@@ -1685,6 +1688,7 @@ requires-dist = [
     { name = "scipy", specifier = "==1.17.1" },
     { name = "seaborn", specifier = "==0.12.2" },
     { name = "shapely", specifier = "==2.1.2" },
+    { name = "superqt", specifier = "==0.8.2" },
     { name = "tifffile", specifier = "==2023.2.28" },
     { name = "torch", marker = "extra == 'prediction'", specifier = ">=2.12.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
@@ -3092,16 +3096,16 @@ wheels = [
 
 [[package]]
 name = "superqt"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "qtpy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "typing-extensions", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/db/ea1c3ffaa2cac333e49ee2718dbfe1378ea4b99d585478076cfed9ab2f88/superqt-0.8.1.tar.gz", hash = "sha256:d9a567e621c2dea0ce4c6c2f7e2237c09c52255e9848ca1594c9a957e2ecb08a", size = 109177, upload-time = "2026-03-27T13:58:01.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/fe/919245507b15b4633cd40292d69c3b6afa8a650bf3ec33f3329d26314a3c/superqt-0.8.2.tar.gz", hash = "sha256:faa3bd00ef1c9b209b1f31b154dd41c596fec3824f61a70c251fb5569acd7ba6", size = 110190, upload-time = "2026-05-18T14:33:47.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e2/249d6b3752247c40391a37a079fe2e9f28bade72dca24503ec54f5c98248/superqt-0.8.1-py3-none-any.whl", hash = "sha256:aadfb37cda7d23397f355fc7a5bf7607dd4199f96de798788ab6ec8d61f3a2fe", size = 101246, upload-time = "2026-03-27T13:57:59.646Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b9/748c3cbcdba20ef01c055a35905cad5c771cc1df29be11b9a82da6fd8e0d/superqt-0.8.2-py3-none-any.whl", hash = "sha256:ce8400ae7b577d090368aae5bdbabb06cd6bc893f6ca73485bb686835bf20943", size = 101595, upload-time = "2026-05-18T14:33:45.462Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Declare `joblib` and `superqt` as direct runtime dependencies because they are imported and used directly by DMC-BrainMap.

## Changes

- Add `joblib==1.5.3` to `pyproject.toml` and `tox.ini`.
- Add `superqt==0.8.2` to `pyproject.toml` and `tox.ini`.
- Refresh `uv.lock`.
- Update the locked SuperQt version from `0.8.1` to `0.8.2`.

## Rationale

- `joblib` is used directly for parallel image preprocessing.
- `superqt.QCollapsible` is used throughout the registration, preprocessing, segmentation, results, and visualization widgets.
- Previously, both packages were installed only as transitive dependencies.
- Declaring them directly prevents unrelated dependency-graph changes from breaking installation.

## Compatibility

SuperQt 0.8.2 does not change the `QCollapsible` API used by the plugin. Its release contains fixes for unrelated slider, quantity, and toggle-switch components.

## Validation

- `uv lock` completed successfully.
- 132 automated tests passed locally.
- No application logic was changed.