### PR TITLE
Modernize TIFF dependency stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "brainglobe-atlasapi==3.0.0rc1",
     "distinctipy==1.3.4",
-    "imagecodecs==2025.3.30",
+    "imagecodecs==2026.3.6",
     "joblib==1.5.3",
     "magicgui==0.10.2",
     "matplotlib==3.10.9",
@@ -47,7 +47,7 @@ dependencies = [
     "shapely==2.1.2",
     "scipy==1.17.1",
     "superqt==0.8.2",
-    "tifffile==2023.2.28",
+    "tifffile==2026.3.3",
 ]
 
 

--- a/test/test_tiff_stack_compatibility.py
+++ b/test/test_tiff_stack_compatibility.py
@@ -1,0 +1,106 @@
+import json
+
+import numpy as np
+import pytest
+import tifffile
+
+from napari_dmc_brainmap.preprocessing import preprocessing_tools
+from napari_dmc_brainmap.stitching import stitching_tools
+
+
+@pytest.mark.parametrize("compression", ["deflate", "lzw"])
+@pytest.mark.parametrize(
+    ("image", "photometric"),
+    [
+        (np.arange(30, dtype=np.uint8).reshape(5, 6), "minisblack"),
+        (np.arange(30, dtype=np.uint16).reshape(5, 6) * 1000, "minisblack"),
+        (
+            np.arange(90, dtype=np.uint8).reshape(5, 6, 3),
+            "rgb",
+        ),
+    ],
+)
+def test_compressed_tiff_round_trip_preserves_array(
+    tmp_path, image, photometric, compression
+):
+    image_path = tmp_path / f"{photometric}_{image.dtype}_{compression}.tif"
+    expected = image.copy()
+
+    tifffile.imwrite(
+        image_path,
+        image,
+        photometric=photometric,
+        compression=compression,
+    )
+    loaded = tifffile.imread(image_path)
+
+    assert loaded.shape == expected.shape
+    assert loaded.dtype == expected.dtype
+    np.testing.assert_array_equal(loaded, expected)
+    np.testing.assert_array_equal(image, expected)
+
+
+def test_save_zstack_preserves_page_order_dtype_and_values(tmp_path):
+    stack_path = tmp_path / "channels_stack.tif"
+    stack = {
+        "dapi": np.full((4, 5), 100, dtype=np.uint16),
+        "green": np.full((4, 5), 200, dtype=np.uint16),
+        "cy3": np.full((4, 5), 300, dtype=np.uint16),
+    }
+    expected = [image.copy() for image in stack.values()]
+
+    preprocessing_tools.save_zstack(stack_path, stack)
+
+    with tifffile.TiffFile(stack_path) as tif:
+        assert len(tif.pages) == 3
+        loaded = [page.asarray() for page in tif.pages]
+
+    for actual, expected_page in zip(loaded, expected, strict=True):
+        assert actual.dtype == np.uint16
+        np.testing.assert_array_equal(actual, expected_page)
+
+    for actual, expected_page in zip(stack.values(), expected, strict=True):
+        np.testing.assert_array_equal(actual, expected_page)
+
+
+def test_load_meta_preserves_imagej_info_json(tmp_path):
+    metadata = {
+        "Prefix": "animal_section",
+        "StagePositions": [
+            {"Label": "Pos0", "GridCol": 0, "GridRow": 0},
+            {"Label": "Pos1", "GridCol": 1, "GridRow": 0},
+        ],
+    }
+    image_path = tmp_path / "metadata.tif"
+    tifffile.imwrite(
+        image_path,
+        np.zeros((4, 5), dtype=np.uint16),
+        imagej=True,
+        metadata={"Info": json.dumps(metadata)},
+    )
+
+    assert stitching_tools.load_meta(tmp_path) == metadata
+
+
+def test_tifffile_fallback_loads_compressed_uint16_without_mutation(
+    tmp_path, monkeypatch
+):
+    image_dir = tmp_path / "stitched" / "green"
+    image_dir.mkdir(parents=True)
+    image_path = image_dir / "section_1_stitched.tif"
+    expected = np.arange(42, dtype=np.uint16).reshape(6, 7) * 1000
+    tifffile.imwrite(
+        image_path,
+        expected,
+        photometric="minisblack",
+        compression="lzw",
+    )
+    monkeypatch.setattr(preprocessing_tools.cv2, "imread", lambda *_: None)
+
+    loaded = preprocessing_tools.load_stitched_images(
+        tmp_path, "green", "section_1"
+    )
+
+    assert loaded.shape == expected.shape
+    assert loaded.dtype == expected.dtype
+    np.testing.assert_array_equal(loaded, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
 deps =
     brainglobe-atlasapi==3.0.0rc1
     distinctipy==1.3.4
+    imagecodecs==2026.3.6
     joblib==1.5.3
     magicgui==0.10.2
     matplotlib==3.10.9
@@ -46,7 +47,7 @@ deps =
     shapely==2.1.2
     scipy==1.17.1
     superqt==0.8.2
-    tifffile==2023.2.28
+    tifffile==2026.3.3
 commands =
     pytest -v --color=yes --cov=napari_dmc_brainmap --cov-report=xml
 

--- a/uv.lock
+++ b/uv.lock
@@ -904,31 +904,20 @@ wheels = [
 
 [[package]]
 name = "imagecodecs"
-version = "2025.3.30"
+version = "2026.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/bf/81c848ffe2b42fc141b6db3e4e8e650183b7aab8c4535498ebff25740a3b/imagecodecs-2025.3.30.tar.gz", hash = "sha256:29256f44a7fcfb8f235a3e9b3bae72b06ea2112e63bcc892267a8c01b7097f90", size = 9506573, upload-time = "2025-03-30T04:44:50.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8d/dc18623e5e926ad53c626e128c8baaf4ec42e41029cf0a07381cfef79289/imagecodecs-2026.3.6.tar.gz", hash = "sha256:471b8a4d1b3843cbf7179b45f7d7261f0c0b28809efc1ca6c47822477b143b85", size = 9565259, upload-time = "2026-03-07T01:26:41.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/09/8c475f73685e864c3742dc38596e3a2b897006402199f42905a09d05395d/imagecodecs-2025.3.30-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:7e0afe1a05a942391abd7d1f25722a07de05d9d12eb6f3ca1ef48e0719c6796a", size = 17946410, upload-time = "2025-03-30T04:43:17.129Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/81/cd6df5a61c85a5f227a3e0b242ad7a04192f8f5dd8b0f65308872e618dbb/imagecodecs-2025.3.30-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:44dc270d78b7cda29e2d430acbd8dab66322766412e596f450871e2831148aa2", size = 15050151, upload-time = "2025-03-30T04:43:20.36Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bc/929ad2025a60e5cfda80330749d6b44ff7a5e1ccf457d998e0e622010881/imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cee56331d9a700e9ec518caeba6d9813ffd7c042f1fae47d2dafcdfc259d2a5", size = 44161549, upload-time = "2025-03-30T04:43:25.322Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/e4/23f8d23822b1fab85edc2b11ee9af7dffc5325e57fc1c05fbd8ba64b67b8/imagecodecs-2025.3.30-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e354fa2046bb7029d0a1ff15a8bb31487ca0d479cd42fdb5c312bcd9408ce3fc", size = 45559360, upload-time = "2025-03-30T04:43:31.614Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d1/4148e036c1f4d4a56aa437dfccf1d1e38ade691242ae4fb1ed6c75198984/imagecodecs-2025.3.30-cp311-cp311-win_amd64.whl", hash = "sha256:7debc7231780d8e44ffcd13aee2178644d93115c19ff73c96cf3068b219ac3a2", size = 28881661, upload-time = "2025-03-30T04:43:41.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/65/52c9ed63fe3ef0601775d3469b495eadf00174ac0f38d9499871866a5e3b/imagecodecs-2025.3.30-cp311-cp311-win_arm64.whl", hash = "sha256:2b5c1c02c70da9561da9b728b97599b3ed0ef7d5399979017ce90029f522587b", size = 23780188, upload-time = "2025-03-30T04:43:45.92Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a8/8d5e87c271ad56076d5d41b29a72bde06f9c576796f658f84be1d704c440/imagecodecs-2025.3.30-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:dad3f0fc39eb9a88cecb2ccfe0e13eac35b21da36c0171285e4b289b12085235", size = 17999942, upload-time = "2025-03-30T04:43:49.422Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/a1/5781188860b9f77ba56743ca70c770bad3500980f6a0be0ead28bfd69679/imagecodecs-2025.3.30-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2806b6e605e674d7e3d21099779a88cb30b9da4807a88e0f02da3ea249085e5f", size = 15088408, upload-time = "2025-03-30T04:43:52.644Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/d6/7dea5c27b5e14746095f3e01a4d5ee4a3e0dbfc534b978675cfd6bbd5270/imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abfb2231f4741262c91f3e77af85ce1f35b7d44f71414c5d1ba6008cfc3e5672", size = 43661256, upload-time = "2025-03-30T04:43:57.461Z" },
-    { url = "https://files.pythonhosted.org/packages/20/ad/f751aed397ad9ba002ace15c028c5261c9dd57e0b366e8642e574332f318/imagecodecs-2025.3.30-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6583fdcac9a4cd75a7701ed7fac7e74d3836807eb9f8aee22f60f519b748ff56", size = 45247507, upload-time = "2025-03-30T04:44:03.489Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/42/e73497e12c5e1f3a98dc0c07a8ac80ee3b728e03cb397475337540b02432/imagecodecs-2025.3.30-cp312-cp312-win_amd64.whl", hash = "sha256:0b0f6e0f118674c76982e5a25bfeec5e6fc4fc4fc102c0d356e370f473e7b512", size = 28889883, upload-time = "2025-03-30T04:44:12.192Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/f0/66792e83443b32442a3c3377e5933b59ccf1be366973cecfc2182ee0840c/imagecodecs-2025.3.30-cp312-cp312-win_arm64.whl", hash = "sha256:bde3bd80cdf65afddb64af4c433549e882a5aa15d300e3781acab8d4df1c94a9", size = 23746584, upload-time = "2025-03-30T04:44:17.341Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e4/9d5fca3816391f28cc3f5310d5765372e60f5208bf8ab1c01c6d1486db86/imagecodecs-2025.3.30-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:0bf7248a7949525848f3e2c7d09e837e8333d52c7ac0436c6eed36235da8227b", size = 17932366, upload-time = "2025-03-30T04:44:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/90/4a13b60aeedcf3ada27cfa6e9a58f0bb1cc50340980f6f9d4a00ced7d753/imagecodecs-2025.3.30-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3e598b6ec77df2517a8d4af6b66393250ba4a8764fccda5dbe6546236df5d11c", size = 15030556, upload-time = "2025-03-30T04:44:24.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/86/03439594c4a7c79dbd85a282387eb399a94702875e58a11e41592dfd8b7c/imagecodecs-2025.3.30-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:212ae6ba7c656ddf24e8aabefc56c5e2300335ed1305838508c57de202e6dbe4", size = 43563048, upload-time = "2025-03-30T04:44:29.186Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/86/21a7f96f5446595df83ba18d20a6f5d2e99eef37c8f0fee807e78bf7e4aa/imagecodecs-2025.3.30-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa7b1c7d7af449c8153a040f7782d4296350245f8809e49dd4fb5bef4d740e6", size = 45213087, upload-time = "2025-03-30T04:44:35.243Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/be/e4aa5ed727ab4178362c695ea862d4c3e25988020ec1b05f8fedbef2ef5f/imagecodecs-2025.3.30-cp313-cp313-win_amd64.whl", hash = "sha256:1c51fef75fec66b4ea5e98b4ab47889942049389278749e1f96329c38f31c377", size = 28865173, upload-time = "2025-03-30T04:44:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ad/5c21694d68a563a0dcbae97b460093ec165efbb795695ea02b24415d6c79/imagecodecs-2025.3.30-cp313-cp313-win_arm64.whl", hash = "sha256:eda70c0b9d2bcf225f7ae12dbefd0e3ab92ea7db30cdb56b292517fb61357ad7", size = 23731786, upload-time = "2025-03-30T04:44:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/db/873d063c99a726d772bf6f076288da59bb12e9f2af3518c2e4de5fde234d/imagecodecs-2026.3.6-cp311-abi3-macosx_10_15_x86_64.whl", hash = "sha256:44cfb3b609d941014f8ac7cf8611b15ccfd7119443bbb6b5e53916b242d31f9e", size = 13953250, upload-time = "2026-03-07T06:13:36.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/36c38a82f033ffbc9e706dad32be7148f130fc00e7bb417ab60e063897a0/imagecodecs-2026.3.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e64037f22980a211b17bf6bdf03f14ff459a7432eec24f7a58c342f6992132fa", size = 11697496, upload-time = "2026-03-07T01:25:56.412Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fa/f67c4e644fdf06503e120f9d1c8d8654b99066dea7093a674b67704fa4a4/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:30fa140bb1a112a889926af36977214ed52a22e4557356043259b5e2f79cfba5", size = 25604431, upload-time = "2026-03-07T01:26:00.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/93ea9cbab7f57b4e60480c51fc51d8e138e399d11797c981d5f6e79f9832/imagecodecs-2026.3.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e30a14aa2e1c6c90e00375292726486c1d90bf003b1414d608ea4d1f62fd8a79", size = 26468592, upload-time = "2026-03-07T01:26:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a7/e3a89b2c516eaca7446e8f1335daeec90764b50888af5e073a2b6a987fcf/imagecodecs-2026.3.6-cp311-abi3-win32.whl", hash = "sha256:c972a45dfee1befbac048ba3492607003e9a185811e8febdc1ed531d48c07e75", size = 15597722, upload-time = "2026-03-07T01:26:08.106Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c7/2b37a7fe9a2eb21011e50f046d62e68ac4e0f8d6ad94d7a10e9f8e8d685f/imagecodecs-2026.3.6-cp311-abi3-win_amd64.whl", hash = "sha256:e8fba5b9ac7be109ed35070208bc1683fa17cc381ed9535a4eae200c6d883bd8", size = 19177403, upload-time = "2026-03-07T01:26:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/94e930cef9e0a29a2df5e3ba3bacd2c2f1e34ca373fe48624b64af8ae91c/imagecodecs-2026.3.6-cp311-abi3-win_arm64.whl", hash = "sha256:fc4856913be6c8b3861223158920d934a0ae203149a435f585622dbbff8ed696", size = 15193605, upload-time = "2026-03-07T01:26:15.016Z" },
 ]
 
 [[package]]
@@ -1662,7 +1651,7 @@ test = [
 requires-dist = [
     { name = "brainglobe-atlasapi", specifier = "==3.0.0rc1" },
     { name = "distinctipy", specifier = "==1.3.4" },
-    { name = "imagecodecs", specifier = "==2025.3.30" },
+    { name = "imagecodecs", specifier = "==2026.3.6" },
     { name = "joblib", specifier = "==1.5.3" },
     { name = "magicgui", specifier = "==0.10.2" },
     { name = "matplotlib", specifier = "==3.10.9" },
@@ -1682,7 +1671,7 @@ requires-dist = [
     { name = "seaborn", specifier = "==0.12.2" },
     { name = "shapely", specifier = "==2.1.2" },
     { name = "superqt", specifier = "==0.8.2" },
-    { name = "tifffile", specifier = "==2023.2.28" },
+    { name = "tifffile", specifier = "==2026.3.3" },
     { name = "torch", marker = "extra == 'prediction'", specifier = ">=2.12.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 provides-extras = ["prediction"]
@@ -3129,14 +3118,14 @@ wheels = [
 
 [[package]]
 name = "tifffile"
-version = "2023.2.28"
+version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/0b/e8123041ebdc361bd5b7b1a9613be4adcbf583befa0a2fc407bc0e71878e/tifffile-2023.2.28.tar.gz", hash = "sha256:2d2baba8dea6609f553fe61853db9a61f715d60ba3bce6a20b5a1ab72407dfed", size = 336265, upload-time = "2023-03-01T07:38:33.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/30/b3a70a98b1be0ef881593b7f0ea7fd2aed9f5f3440e90547aa79000a8792/tifffile-2023.2.28-py3-none-any.whl", hash = "sha256:8357cd8ccbdd4378ad4d6b84ffe3ab15b1d96630b1719f576d4de386f45546f1", size = 216374, upload-time = "2023-03-01T07:38:31.425Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade `tifffile` from 2023.2.28 to 2026.3.3.
- Upgrade `imagecodecs` from 2025.3.30 to 2026.3.6.
- Add `imagecodecs` explicitly to the minimal tox environment.
- Refresh `uv.lock`.

These are the newest releases in their respective release lines that support the project’s Python 3.11–3.13 boundary.

## API compatibility

The project’s active TIFF APIs were audited:

- `tifffile.imread`
- `tifffile.imwrite`
- `TiffFile`
- `TiffFile.asarray`
- `TiffFile.pages`
- `TiffFile.imagej_metadata`
- `TiffWriter`
- `TiffWriter.write`

No incompatible API usage was found, and no application code changes were required.

Upstream breaking changes involving Zarr stores, command-line interfaces, removed legacy aliases, and direct imagecodecs functions do not affect the APIs used by this project.

## Tests

Added regression coverage for:

- 8-bit and 16-bit grayscale TIFF files
- 8-bit RGB TIFF files
- LZW and Deflate compression
- Multipage stack order, dtype, and values
- ImageJ `Info` JSON metadata
- OpenCV-to-tifffile fallback loading
- Input-array non-mutation

The tests were run before and after the dependency upgrade to confirm consistent output.

## Validation

- Existing TIFF stack baseline: 9 tests passed.
- Upgraded focused TIFF and presegmentation suite: 28 tests passed.
- Python 3.13 full suite: 161 tests passed.
- Python 3.11 tox suite: 161 tests passed.