### PR TITLE
Upgrade seaborn and preserve plotting behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "scikit-image==0.26.0",
     "scikit-learn==1.9.0",
     "scikit-spatial==9.0.1",
-    "seaborn==0.12.2",
+    "seaborn==0.13.2",
     "shapely==2.1.2",
     "scipy==1.17.1",
     "superqt==0.8.2",

--- a/src/napari_dmc_brainmap/visualization/vis_plots/barplot_visualization.py
+++ b/src/napari_dmc_brainmap/visualization/vis_plots/barplot_visualization.py
@@ -317,15 +317,18 @@ class BarplotVisualization:
         bar_palette = self._check_color_palette(self.plotting_params["bar_palette"])
         scatter_palette = self._check_color_palette(self.plotting_params["scatter_palette"], bar=False)
         if self.plotting_params["groups"] == '' and not self.plotting_params['gene_list']:
+            category_var = y_var if plot_orient == 'h' else x_var
             sns.barplot(
                 ax=static_ax,
                 x=x_var,
                 y=y_var,
                 data=data,
+                hue=category_var,
                 palette=bar_palette,
                 capsize=.1,
                 errorbar=None,
-                orient=plot_orient)
+                orient=plot_orient,
+                legend=False)
             if self.plotting_params["scatter_hue"]:
                 sns.swarmplot(
                     ax=static_ax,
@@ -356,19 +359,28 @@ class BarplotVisualization:
             y_var (str): Y-axis variable.
             plot_orient (str): Plot orientation ('h' for horizontal, 'v' for vertical).
         """
-        palette = self.color_manager.create_color_palette([], self.plotting_params, "bar_palette", df=data, hue_id='genes') if len(self.plotting_params['gene_list']) > 1 else self.plotting_params["bar_palette"]
-        if len(self.plotting_params['gene_list']) == 1:
-            palette = self._check_color_palette(palette.values())
+        multiple_genes = len(self.plotting_params['gene_list']) > 1
+        if multiple_genes:
+            palette = self.color_manager.create_color_palette(
+                [], self.plotting_params, "bar_palette", df=data, hue_id='genes'
+            )
+            hue = 'genes'
+            legend = 'auto'
+        else:
+            palette = self._check_color_palette(self.plotting_params["bar_palette"])
+            hue = y_var if plot_orient == 'h' else x_var
+            legend = False
         sns.barplot(
                 ax=static_ax,
                 x=x_var,
                 y=y_var,
                 data=data,
-                hue='genes' if len(self.plotting_params['gene_list']) > 1 else None,
+                hue=hue,
                 palette=palette,
                 capsize=.1,
                 errorbar=None,
-                orient=plot_orient
+                orient=plot_orient,
+                legend=legend
             )
 
     def _plot_group_data(

--- a/test/test_plotting_stack_compatibility.py
+++ b/test/test_plotting_stack_compatibility.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import warnings
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from napari_dmc_brainmap.utils.color_manager import ColorManager
+from napari_dmc_brainmap.visualization.vis_plots.barplot_visualization import (
+    BarplotVisualization,
+)
+from napari_dmc_brainmap.visualization.vis_plots.brainsection_visualization import (
+    BrainsectionVisualization,
+)
+
+
+def _barplot(groups: str = "") -> BarplotVisualization:
+    plotter = object.__new__(BarplotVisualization)
+    plotter.plotting_params = {
+        "bar_palette": ["#ff0000", "#0000ff"],
+        "scatter_palette": ["#008000", "#800080"],
+        "scatter_hue": False,
+        "scatter_size": 4,
+        "groups": groups,
+        "gene_list": [],
+    }
+    plotter.color_manager = ColorManager()
+    return plotter
+
+
+def _facecolors(axis: plt.Axes) -> list[str]:
+    return [mcolors.to_hex(patch.get_facecolor()) for patch in axis.patches]
+
+
+def test_ungrouped_barplot_preserves_category_order_and_palette():
+    plotter = _barplot()
+    data = pd.DataFrame(
+        {
+            "tgt_name": ["VTA", "VTA", "MB", "MB"],
+            "percent": [20.0, 40.0, 10.0, 30.0],
+            "animal_id": ["a1", "a2", "a1", "a2"],
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_data(axis, data, "tgt_name", "percent", "v")
+
+    assert [tick.get_text() for tick in axis.get_xticklabels()] == ["VTA", "MB"]
+    assert [patch.get_height() for patch in axis.patches] == [30.0, 20.0]
+    assert _facecolors(axis) == ["#df2020", "#2020df"]
+    assert not axis.lines
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)
+
+
+def test_horizontal_ungrouped_barplot_uses_target_as_redundant_hue():
+    plotter = _barplot()
+    data = pd.DataFrame(
+        {
+            "tgt_name": ["VTA", "MB"],
+            "percent": [30.0, 20.0],
+        }
+    )
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_data(axis, data, "percent", "tgt_name", "h")
+
+    assert [tick.get_text() for tick in axis.get_yticklabels()] == ["VTA", "MB"]
+    assert [patch.get_width() for patch in axis.patches] == [30.0, 20.0]
+    assert _facecolors(axis) == ["#df2020", "#2020df"]
+    assert axis.get_legend() is None
+    plt.close(figure)
+
+
+def test_grouped_barplot_preserves_hue_order_palette_and_values():
+    plotter = _barplot(groups="group")
+    data = pd.DataFrame(
+        {
+            "tgt_name": ["VTA", "VTA", "MB", "MB"],
+            "percent": [20.0, 40.0, 10.0, 30.0],
+            "groups": ["control", "treated", "control", "treated"],
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_group_data(axis, data, "tgt_name", "percent", "v")
+
+    assert [tick.get_text() for tick in axis.get_xticklabels()] == ["VTA", "MB"]
+    assert [text.get_text() for text in axis.get_legend().get_texts()] == [
+        "control",
+        "treated",
+    ]
+    assert [patch.get_height() for patch in axis.patches[:4]] == [20.0, 10.0, 40.0, 30.0]
+    assert _facecolors(axis)[:4] == ["#df2020", "#df2020", "#2020df", "#2020df"]
+    assert not axis.lines
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)
+
+
+def test_single_gene_barplot_accepts_widget_palette_without_legend():
+    plotter = _barplot()
+    plotter.plotting_params["gene_list"] = ["gene_a"]
+    data = pd.DataFrame(
+        {
+            "tgt_name": ["VTA", "MB"],
+            "percent": [0.25, 0.75],
+            "genes": ["gene_a", "gene_a"],
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_expression(axis, data, "tgt_name", "percent", "v")
+
+    assert [tick.get_text() for tick in axis.get_xticklabels()] == ["VTA", "MB"]
+    assert [patch.get_height() for patch in axis.patches] == [0.25, 0.75]
+    assert _facecolors(axis) == ["#df2020", "#2020df"]
+    assert axis.get_legend() is None
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)
+
+
+def test_multiple_gene_barplot_preserves_gene_hue_and_legend_order():
+    plotter = _barplot()
+    plotter.plotting_params["gene_list"] = ["gene_a", "gene_b"]
+    data = pd.DataFrame(
+        {
+            "tgt_name": ["VTA", "VTA", "MB", "MB"],
+            "percent": [0.25, 0.5, 0.75, 1.0],
+            "genes": ["gene_a", "gene_b", "gene_a", "gene_b"],
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_expression(axis, data, "tgt_name", "percent", "v")
+
+    assert [tick.get_text() for tick in axis.get_xticklabels()] == ["VTA", "MB"]
+    assert [text.get_text() for text in axis.get_legend().get_texts()] == [
+        "gene_a",
+        "gene_b",
+    ]
+    assert [patch.get_height() for patch in axis.patches[:4]] == [
+        0.25,
+        0.75,
+        0.5,
+        1.0,
+    ]
+    assert _facecolors(axis)[:4] == ["#df2020", "#df2020", "#2020df", "#2020df"]
+    assert not axis.lines
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)
+
+
+def test_injection_kde_preserves_input_and_draws_filled_density():
+    plotter = object.__new__(BrainsectionVisualization)
+    plotter.orient_mapping = {"x_plot": "ml_coords", "y_plot": "dv_coords"}
+    plotter.plotting_params = {"groups": "group"}
+    plotter.color_dict = {
+        "injection_site": {
+            "single_color": True,
+            "cmap": "#336699",
+        }
+    }
+    data = pd.DataFrame(
+        {
+            "ml_coords": [0.0, 0.7, 1.1, 1.8, 2.2, 2.9],
+            "dv_coords": [0.1, 0.4, 1.3, 1.0, 2.1, 2.7],
+            "group": ["control"] * 6,
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message="use_inf_as_na option is deprecated",
+            category=FutureWarning,
+        )
+        plotter._plot_injection_site(axis, data, "injection_site")
+
+    assert axis.collections
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)
+
+
+def test_probe_regression_is_line_only_without_confidence_band():
+    plotter = object.__new__(BrainsectionVisualization)
+    plotter.orient_mapping = {"x_plot": "ml_coords", "y_plot": "dv_coords"}
+    plotter.color_dict = {
+        "optic_fiber": {
+            "single_color": True,
+            "cmap": "#336699",
+        }
+    }
+    data = pd.DataFrame(
+        {
+            "ml_coords": [0.0, 1.0, 2.0, 3.0],
+            "dv_coords": [1.0, 3.0, 5.0, 7.0],
+        }
+    )
+    source = data.copy(deep=True)
+    figure, axis = plt.subplots()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        plotter._plot_optic_or_probe(axis, data, "optic_fiber")
+
+    assert len(axis.lines) == 1
+    assert axis.lines[0].get_xdata()[[0, -1]].tolist() == [0.0, 3.0]
+    assert axis.lines[0].get_ydata()[[0, -1]].tolist() == pytest.approx([1.0, 7.0])
+    assert not axis.collections
+    pd.testing.assert_frame_equal(data, source)
+    plt.close(figure)

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     scikit-image==0.26.0
     scikit-learn==1.9.0
     scikit-spatial==9.0.1
-    seaborn==0.12.2
+    seaborn==0.13.2
     shapely==2.1.2
     scipy==1.17.1
     superqt==0.8.2

--- a/uv.lock
+++ b/uv.lock
@@ -1668,7 +1668,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = "==1.9.0" },
     { name = "scikit-spatial", specifier = "==9.0.1" },
     { name = "scipy", specifier = "==1.17.1" },
-    { name = "seaborn", specifier = "==0.12.2" },
+    { name = "seaborn", specifier = "==0.13.2" },
     { name = "shapely", specifier = "==2.1.2" },
     { name = "superqt", specifier = "==0.8.2" },
     { name = "tifffile", specifier = "==2026.3.3" },
@@ -2980,16 +2980,16 @@ wheels = [
 
 [[package]]
 name = "seaborn"
-version = "0.12.2"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "numpy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pandas", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/77/5cde8bc47df770486acf64f550839b4136d1696e5e4d57ce33fa1823972b/seaborn-0.12.2.tar.gz", hash = "sha256:374645f36509d0dcab895cba5b47daf0586f77bfe3b36c97c607db7da5be0139", size = 1439798, upload-time = "2022-12-30T19:25:38.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/2e/17bbb83fbf102687bb2aa3d808add39da820a7698159302a1a69bb82e01c/seaborn-0.12.2-py3-none-any.whl", hash = "sha256:ebf15355a4dba46037dfd65b7350f014ceb1f13c05e814eda2c9f5fd731afc08", size = 293284, upload-time = "2022-12-30T19:25:36.518Z" },
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade seaborn from 0.12.2 to 0.13.2.
- Update the lockfile and tox dependency declarations.
- Adapt categorical barplots to seaborn's explicit `hue` behavior while preserving existing colors, ordering, values, and legends.
- Fix single-gene barplots so list-based palettes supplied by the GUI are handled correctly.
- Restore filled KDE compatibility with the current Matplotlib version.

## Regression coverage

Add focused tests covering:

- vertical and horizontal ungrouped barplots
- grouped barplots and hue ordering
- single-gene and multi-gene plots
- palette and legend behavior
- disabled error bars
- filled injection-site KDE plots
- line-only probe trajectory regression
- input DataFrame non-mutation

## Testing

- Full test suite: `168 passed`
- Isolated Python 3.11 tox environment: `168 passed`
- No seaborn compatibility warnings remain