### PR TITLE
Modernize CI workflow and Python test matrix

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,63 +1,96 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: tests
 
 on:
   push:
     branches:
       - main
-      - "feature/**"
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    name: ${{ matrix.platform }} py${{ matrix.python-version }} (${{ matrix.tox-env }})
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.11']
+        include:
+          - platform: ubuntu-latest
+            python-version: '3.11'
+            tox-env: py311-full
+            coverage: true
+          - platform: windows-latest
+            python-version: '3.11'
+            tox-env: py311
+            coverage: false
+          - platform: macos-15
+            python-version: '3.11'
+            tox-env: py311
+            coverage: false
+          - platform: ubuntu-latest
+            python-version: '3.13'
+            tox-env: py313-full
+            coverage: false
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      # these libraries enable testing on Qt on linux
-      - uses: tlambert03/setup-qt-libs@v1
+      - name: Install Linux display libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libegl1 \
+            libdbus-1-3 \
+            libxkbcommon-x11-0 \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libxcb-xinput0 \
+            libxcb-xfixes0 \
+            libxcb-cursor0 \
+            libopengl0
 
-      # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
           git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
-      # note: if you need dependencies from conda, considering using
-      # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
-      # and
-      # tox-conda: https://github.com/tox-dev/tox-conda
-      - name: Install dependencies
+      - name: Install test tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools tox tox-gh-actions tox-uv
+          python -m pip install tox tox-uv
 
-      # this runs the platform-specific tests declared in tox.ini
+      - name: Test with tox on Linux
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum python -m tox -e "${{ matrix.tox-env }}"
+
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: python -m tox
-        env:
-          PLATFORM: ${{ matrix.platform }}
+        if: runner.os != 'Linux'
+        run: python -m tox -e "${{ matrix.tox-env }}"
 
-      - name: Coverage
-        uses: codecov/codecov-action@v2
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = py311
+envlist = py311, py313
 isolated_build = true
 requires =
     tox-uv>=1
-
-[gh-actions]
-python =
-    3.11: py311
 
 [testenv]
 description = run the test suite with its minimal runtime dependencies
@@ -53,6 +49,18 @@ commands =
 
 [testenv:py311-full]
 description = install the complete package dependency graph and run the tests
+basepython = python3.11
+skip_install = false
+setenv =
+    QT_QPA_PLATFORM = offscreen
+deps =
+    pyqt6
+    pytest
+    pytest-cov
+
+[testenv:py313-full]
+description = install the complete package dependency graph on Python 3.13 and run the tests
+basepython = python3.13
 skip_install = false
 setenv =
     QT_QPA_PLATFORM = offscreen


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v3 to v6.
- Upgrade `actions/setup-python` from v4 to v6.
- Upgrade `codecov/codecov-action` from v2 to v7.
- Replace the archived Qt setup action and legacy Xvfb wrapper with explicit Linux packages and `xvfb-run`.
- Remove the unused `tox-gh-actions` dependency and configuration.
- Add explicit Python 3.13 and full-package installation coverage.
- Test macOS on an Apple Silicon runner.
- Upload coverage from one representative job instead of every platform.
- Add read-only permissions, concurrency cancellation, and `fail-fast: false`.
- Remove obsolete deployment comments and unused tag and feature-branch triggers.

## Test matrix

| Platform | Python | Tox environment | Coverage upload |
|---|---:|---|---|
| Ubuntu | 3.11 | `py311-full` | Yes |
| Windows | 3.11 | `py311` | No |
| macOS 15 Apple Silicon | 3.11 | `py311` | No |
| Ubuntu | 3.13 | `py313-full` | No |

## Tox changes

- Add Python 3.13 to the default environment list.
- Activate the existing `py311-full` environment.
- Add `py313-full` for complete package installation testing.
- Remove the obsolete GitHub Actions environment mapping.

## Validation

- Workflow YAML parsed successfully with all four matrix entries.
- Python 3.11 full-install environment: `168 passed`.
- Python 3.13 full-install environment: `168 passed`.

## Workflow triggers

Tests now run for:

- pull requests targeting `main`
- pushes to `main`
- manual workflow dispatch

Branch pushes do not run a duplicate workflow before a pull request is opened.