### PR TITLE
Fix Matplotlib 3.10 canvas compatibility in registration

### DIFF
--- a/src/napari_dmc_brainmap/registration/registration.py
+++ b/src/napari_dmc_brainmap/registration/registration.py
@@ -389,8 +389,13 @@ class RegistrationWidget(QWidget):
         self.reg_viewer.widget.viewerLeft.scene.changed.disconnect()
         self.reg_viewer.widget.viewerRight.scene.changed.disconnect()
 
-        if not self.reg_viewer.interpolatePositionAct.isEnabled():
-            self.reg_viewer.interpolatePositionPage.close()
+        interpolate_position_page = getattr(
+            self.reg_viewer,
+            "interpolatePositionPage",
+            None,
+        )
+        if interpolate_position_page is not None:
+            interpolate_position_page.close()
         
         if not self.reg_viewer.measurementAct.isEnabled():
             self.reg_viewer.measurementPage.close()

--- a/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/model/HelperModel.py
+++ b/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/model/HelperModel.py
@@ -3,6 +3,13 @@ import matplotlib.pyplot as plt
 from qtpy.QtGui import QPixmap,QImage
 
 
+def _canvas_to_rgb_array(canvas):
+    """Render a Matplotlib canvas as an owned, contiguous RGB array."""
+    canvas.draw()
+    rgba = np.asarray(canvas.buffer_rgba())
+    return np.ascontiguousarray(rgba[..., :3])
+
+
 class HelperModel():
     def __init__(self,regViewer):
         self.regViewer = regViewer
@@ -53,10 +60,8 @@ class HelperModel():
                       labels=[self.z_mm_ant_str,"0 mm",self.z_mm_pos_str],fontsize=7)
         
         # fig.tight_layout(pad=0)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        self.img0 = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        plt.close()
+        self.img0 = _canvas_to_rgb_array(fig.canvas)
+        plt.close(fig)
     
 
     def update_illustration(self):
@@ -89,10 +94,8 @@ class HelperModel():
                                 "facecolor":"yellow",
                                 "lw": 0.5})
         # fig.tight_layout(pad=0)
-        fig.canvas.draw()
-        img = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-        self.img = img.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-        plt.close()
+        self.img = _canvas_to_rgb_array(fig.canvas)
+        plt.close(fig)
         # update image in QLabel
         h,w,_ = self.img.shape
         previewimg_update = QImage(self.img.data, w, h, 3 * w, QImage.Format_RGB888)

--- a/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/view/RegistrationViewer.py
+++ b/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/view/RegistrationViewer.py
@@ -190,9 +190,10 @@ class RegistrationViewer(QMainWindow):
         self.menuBar().addMenu(self.helpMenu)
     
     def interpolatePositionPageOpen(self):
+        interpolate_position_page = InterpolatePosition(self)
+        interpolate_position_page.show()
+        self.interpolatePositionPage = interpolate_position_page
         self.interpolatePositionAct.setEnabled(False)
-        self.interpolatePositionPage = InterpolatePosition(self)
-        self.interpolatePositionPage.show()
     
     def measurementPageOpen(self):
         self.measurementAct.setEnabled(False)

--- a/test/test_registration_matplotlib_compatibility.py
+++ b/test/test_registration_matplotlib_compatibility.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+from napari_dmc_brainmap.registration.registration import RegistrationWidget
+from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.model.HelperModel import (
+    HelperModel,
+    _canvas_to_rgb_array,
+)
+from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.view import (
+    RegistrationViewer as registration_viewer_module,
+)
+from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.view.RegistrationViewer import (
+    RegistrationViewer,
+)
+
+
+class _Action:
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+
+    def isEnabled(self):
+        return self.enabled
+
+    def setEnabled(self, enabled):
+        self.enabled = enabled
+
+
+def test_canvas_to_rgb_array_supports_current_matplotlib_api():
+    figure = Figure(figsize=(2, 1), dpi=20)
+    canvas = FigureCanvasAgg(figure)
+    figure.patch.set_facecolor((0.25, 0.5, 0.75, 1.0))
+
+    image = _canvas_to_rgb_array(canvas)
+
+    assert image.shape == (20, 40, 3)
+    assert image.dtype == np.uint8
+    assert image.flags.c_contiguous
+    assert image.flags.owndata
+    np.testing.assert_array_equal(image[0, 0], [64, 128, 191])
+
+
+def test_helper_model_renders_initial_and_updated_illustrations(monkeypatch):
+    helper_model_module = __import__(
+        _canvas_to_rgb_array.__module__,
+        fromlist=["HelperModel"],
+    )
+
+    class _QImage:
+        Format_RGB888 = object()
+
+        def __init__(self, *args):
+            self.args = args
+
+    class _QPixmap:
+        @staticmethod
+        def fromImage(image):
+            return image
+
+    class _PreviewLabel:
+        def __init__(self):
+            self.pixmap = None
+
+        def setPixmap(self, pixmap):
+            self.pixmap = pixmap
+
+    monkeypatch.setattr(helper_model_module, "QImage", _QImage)
+    monkeypatch.setattr(helper_model_module, "QPixmap", _QPixmap)
+
+    preview_label = _PreviewLabel()
+    viewer = SimpleNamespace(
+        atlasModel=SimpleNamespace(
+            template=np.zeros((80, 60, 4), dtype=np.uint16),
+            xyz_dict={
+                "x": (0, 4, 25),
+                "y": (0, 60, 25),
+                "z": (0, 80, 25),
+            },
+            bregma=(40, 0, 0),
+            z_idx=0,
+        ),
+        status=SimpleNamespace(sliceNum=3, decimal=2),
+        interpolatePositionPage=SimpleNamespace(preview_label=preview_label),
+    )
+
+    model = HelperModel(viewer)
+    model.update_illustration()
+
+    assert model.img0.ndim == 3
+    assert model.img0.shape[2] == 3
+    assert model.img0.dtype == np.uint8
+    assert model.img0.flags.c_contiguous
+    assert model.img.shape == model.img0.shape
+    assert model.img.dtype == np.uint8
+    assert model.img.flags.c_contiguous
+    assert preview_label.pixmap is not None
+
+
+def test_interpolation_action_changes_only_after_page_opens(monkeypatch):
+    class _Page:
+        def __init__(self, viewer):
+            self.viewer = viewer
+            self.shown = False
+
+        def show(self):
+            self.shown = True
+
+    monkeypatch.setattr(registration_viewer_module, "InterpolatePosition", _Page)
+    viewer = SimpleNamespace(interpolatePositionAct=_Action())
+
+    RegistrationViewer.interpolatePositionPageOpen(viewer)
+
+    assert viewer.interpolatePositionPage.shown
+    assert not viewer.interpolatePositionAct.isEnabled()
+
+
+def test_failed_interpolation_page_construction_leaves_action_enabled(monkeypatch):
+    def _raise_during_construction(viewer):
+        raise RuntimeError("construction failed")
+
+    monkeypatch.setattr(
+        registration_viewer_module,
+        "InterpolatePosition",
+        _raise_during_construction,
+    )
+    viewer = SimpleNamespace(interpolatePositionAct=_Action())
+
+    with pytest.raises(RuntimeError, match="construction failed"):
+        RegistrationViewer.interpolatePositionPageOpen(viewer)
+
+    assert viewer.interpolatePositionAct.isEnabled()
+    assert not hasattr(viewer, "interpolatePositionPage")
+
+
+def test_registration_cleanup_tolerates_missing_interpolation_page():
+    class _Signal:
+        def disconnect(self):
+            pass
+
+    scene = SimpleNamespace(changed=_Signal())
+    reg_viewer = SimpleNamespace(
+        widget=SimpleNamespace(
+            viewerLeft=SimpleNamespace(scene=scene),
+            viewerRight=SimpleNamespace(scene=scene),
+        ),
+        interpolatePositionAct=_Action(enabled=False),
+        measurementAct=_Action(),
+        shortcutsAct=_Action(),
+        regViewerWidget=object(),
+        app=object(),
+        regi_dict={},
+        status=object(),
+        atlasModel=object(),
+    )
+    registration_widget = SimpleNamespace(reg_viewer=reg_viewer)
+
+    RegistrationWidget.del_regviewer_instance(registration_widget)
+
+    assert not hasattr(registration_widget, "reg_viewer")


### PR DESCRIPTION
## Summary

Fixes the Interpolate Position registration widget under Matplotlib 3.10, which removed the deprecated `FigureCanvas.tostring_rgb()` API.

## Changes

- replace both `tostring_rgb()` calls with `buffer_rgba()`
- convert RGBA output into owned, contiguous three-channel `uint8` arrays
- preserve compatibility with Qt `QImage` rendering
- cover both the initial position illustration and subsequent preview updates
- disable the interpolation action only after the window opens successfully
- allow registration cleanup when interpolation-window construction fails

## Testing

- added a Matplotlib canvas conversion contract test
- added coverage for initial and updated interpolation illustrations
- added successful and failed window-construction tests
- added cleanup coverage for a missing interpolation window
- verified the removed API is no longer used in active code
- full local test suite: **219 passed**

## Manual test

- open registration with real data
- open **Interpolate Position**
- add or modify an anchor and confirm the illustration updates
- close the interpolation window and registration viewer normally