### PR TITLE
chore(release): prepare 0.2.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+## 0.2.0b1 - 2026-08-11
+
+This is a beta release of the next DMC-BrainMap feature series. It contains
+substantial atlas, scientific-stack, stitching, and packaging changes. The
+automated test suite covers the supported platforms and core compatibility
+contracts, but manual testing across real-world datasets and workflows is still
+in progress.
+
+### Highlights
+
+- Migrated atlas integration from BrainGlobe Atlas API 1.x to the 3.x API.
+- Moved derived atlas volumes into the platform-specific application cache and
+  added offline API contract coverage.
+- Replaced the AICS-based presegmentation path with an internal implementation
+  while preserving supported grayscale and RGB behavior through regression
+  fixtures.
+- Reworked rigid-overlap stitching to infer ImageJ-compatible acquisition
+  layouts from embedded TIFF metadata and stream tiles into a local scratch
+  canvas.
+- Added lossless compressed TIFF publishing with validated destinations,
+  scratch-space checks, operation-specific partial files, and safe handling of
+  local and network storage.
+- Modernized the NumPy, pandas, SciPy, scikit-learn, scikit-image, TIFF,
+  plotting, and napari GUI dependency stacks.
+- Fixed registration illustration rendering for the Matplotlib 3.10 canvas API.
+- Added optional prediction-assisted registration without making PyTorch a
+  required plugin dependency.
+
+### Compatibility
+
+- Python 3.11, 3.12, and 3.13 are supported.
+- Intel macOS is no longer supported; macOS support targets Apple Silicon.
+- BrainGlobe Atlas API is pinned to `3.0.0rc1` for this beta.
+- Existing users must download Atlas API v3 atlas data and regenerate derived
+  application caches rather than migrate legacy `reference_8bit` caches.
+- The SHARPy-track Cy3 default contrast range is now `50,500`, matching direct
+  stitching.
+
+### Testing status
+
+- Automated tests cover Ubuntu with Python 3.11 and 3.13, Windows with Python
+  3.11, and Apple Silicon macOS with Python 3.11.
+- The local release-preparation suite contains 219 passing tests.
+- Stitching was exercised with a real 54-tile acquisition and an SMB network
+  destination.
+- Atlas-dependent manual testing covered the primary registration,
+  preprocessing, stitching, segmentation, and visualization workflows, but the
+  beta should still be validated against additional datasets before the final
+  `0.2.0` release.
+
+### Installation
+
+Pre-releases are not selected by a normal pip upgrade. Install this beta
+explicitly:
+
+```bash
+pip install napari-dmc-brainmap==0.2.0b1
+```
+
+Please report regressions with the operating system, Python version, atlas,
+input image format, and a minimal traceback or reproduction procedure.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE.txt
 include README.md
+include CHANGELOG.md
 
 include src/napari_dmc_brainmap/utils/xkcd.json
 include src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/images/empty.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "napari-dmc-brainmap"
-version = "0.1.8"
+version = "0.2.0b1"
 description = "DMC-BrainMap is an end-to-end tool for multi-feature brain mapping across species"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -10,7 +10,7 @@ authors = [
     { name = "Felix Jung", email = "jung.neurosc@gmail.com" },
 ]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Framework :: napari",
     "Intended Audience :: Developers",
     "Operating System :: MacOS :: MacOS X",

--- a/uv.lock
+++ b/uv.lock
@@ -1604,7 +1604,7 @@ wheels = [
 
 [[package]]
 name = "napari-dmc-brainmap"
-version = "0.1.8"
+version = "0.2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "brainglobe-atlasapi", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },


### PR DESCRIPTION
## Summary

Prepares the first beta release of DMC-BrainMap 0.2.0.

## Changes

- update the package version to `0.2.0b1`
- mark the release as Beta in package metadata
- synchronize the uv lockfile
- add release notes covering changes since `v0.1.8`
- include the changelog in source distributions

## Validation

- full local suite: **219 passed**
- wheel and source distribution built successfully
- both artifacts pass `twine check`
- package version, Python requirements, napari entry point, and bundled resources verified

## Release note

This PR only prepares the release metadata. PyPI publication and the `v0.2.0b1` tag will be created after this PR passes CI and is merged.