### PR TITLE
Upgrade BrainGlobe Atlas API to 3.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [
-    "brainglobe-atlasapi==3.0.0rc1",
+    "brainglobe-atlasapi==3.0.1",
     "distinctipy==1.3.4",
     "imagecodecs==2026.3.6",
     "joblib==1.5.3",

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     PYTHONPATH = {toxinidir}/src
     QT_QPA_PLATFORM = offscreen
 deps =
-    brainglobe-atlasapi==3.0.0rc1
+    brainglobe-atlasapi==3.0.1
     distinctipy==1.3.4
     imagecodecs==2026.3.6
     joblib==1.5.3

--- a/uv.lock
+++ b/uv.lock
@@ -215,9 +215,10 @@ wheels = [
 
 [[package]]
 name = "brainglobe-atlasapi"
-version = "3.0.0rc1"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiobotocore", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "brainglobe-space", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "click", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "dracopy", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
@@ -231,11 +232,12 @@ dependencies = [
     { name = "rich", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "s3fs", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "tifffile", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "treelib", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/23/0aaebebb2b8446f1094b5843d0b263252fb5c6a7b62ae87df4684ac82827/brainglobe_atlasapi-3.0.0rc1.tar.gz", hash = "sha256:7e6f2876c6daa1efe74cab1e3ff9751defd0a48aef158cac6192085a5ca59217", size = 74158, upload-time = "2026-07-17T14:34:55.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a7/702c406ef219a5823cd42fb7ab2c0574df03510691497f3535ee0004b08d/brainglobe_atlasapi-3.0.1.tar.gz", hash = "sha256:c57897faefc03d4bfa7eab9cf727eefa7ae065d875c7acc7ff5a8dc2498e546c", size = 74599, upload-time = "2026-08-10T15:35:52.968Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/dd/0297a8648d3b6a0f0076b5a37c99a1d06ed73e64704c0217b033c379e9b6/brainglobe_atlasapi-3.0.0rc1-py3-none-any.whl", hash = "sha256:704cd25397b14a436f7b6aa181cd639ea21c464ccfd944fdc280574b46d5f755", size = 74941, upload-time = "2026-07-17T14:34:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fb/d6381e3233ef9036b8012cf93444f6d08c26cd188f3e95b31a266585e3b3/brainglobe_atlasapi-3.0.1-py3-none-any.whl", hash = "sha256:47219ac4487f41c3e395040b86819f1825102597e9fd4154e2781e2d0d82827f", size = 73622, upload-time = "2026-08-10T15:35:51.772Z" },
 ]
 
 [[package]]
@@ -1649,7 +1651,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "brainglobe-atlasapi", specifier = "==3.0.0rc1" },
+    { name = "brainglobe-atlasapi", specifier = "==3.0.1" },
     { name = "distinctipy", specifier = "==1.3.4" },
     { name = "imagecodecs", specifier = "==2026.3.6" },
     { name = "joblib", specifier = "==1.5.3" },


### PR DESCRIPTION
## Summary

Upgrade `brainglobe-atlasapi` from `3.0.0rc1` to `3.0.1`.

The release candidate used the retired `atlas-rc2` S3 path when fetching `last_versions.conf`, resulting in a remote 404 and preventing the parameters widget from loading when no cached version was available. Version 3.0.1 uses the current `/atlas/` endpoint.

## Changes

- Update the dependency pin in `pyproject.toml`.
- Update the test dependency pin in `tox.ini`.
- Update `uv.lock`, including the runtime dependencies declared by 3.0.1.

## Compatibility review

The rc1 and 3.0.1 packages were compared before upgrading:

- No existing public function or method signatures changed.
- No classes or Python modules were added or removed.
- The plugin does not use the changed private atlas-generation helpers.
- Live atlas listing and download behavior were verified.
- An `example_mouse_100um` atlas was downloaded, loaded, and queried successfully.

## Validation

- Local locked test suite: 219 passed.
- `uv lock --check`: passed.
- Installed dependency compatibility check: passed.
- GitHub Actions passed on:
  - Windows latest, Python 3.11
  - macOS 15, Python 3.11
  - Ubuntu latest, Python 3.11
  - Ubuntu latest, Python 3.13

CI run: https://github.com/hejDMC/napari-dmc-brainmap/actions/runs/31585085975