### PR TITLE
Fix preprocessing contrast adjustment toggle

### DIFF
--- a/src/napari_dmc_brainmap/preprocessing/preprocessing.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing.py
@@ -281,10 +281,11 @@ class PreprocessingWidget(QWidget):
 
         base_info = {"channels": imaged_chan_list, "downsampling": widget[2].value}
 
-        if item == 'sharpy_track':
-            base_info["contrast_adjustment"] = widget[2].value
-        elif item != 'binary':
-            base_info["contrast_adjustment"] = widget[3].value
+        if item != 'binary':
+            contrast_widget_index = 2 if item == 'sharpy_track' else 3
+            base_info["contrast_adjustment"] = widget[
+                contrast_widget_index
+            ].value
 
         if item == 'binary':
             if widget[4].value:  # manual thresholds
@@ -293,10 +294,23 @@ class PreprocessingWidget(QWidget):
                                   enumerate(chan_list) if channel in imaged_chan_list})
             else:
                 base_info.update({"manual_threshold": widget[4].value, "thresh_method": widget[3].value.value})
+        elif base_info["contrast_adjustment"]:
+            contrast_start_index = 3 if item == 'sharpy_track' else 4
+            base_info.update({
+                channel: [
+                    int(i)
+                    for i in widget[
+                        contrast_start_index + idx
+                    ].value.split(',')
+                ]
+                for idx, channel in enumerate(chan_list)
+                if channel in imaged_chan_list
+            })
         else:
             base_info.update({
-                channel: [int(i) for i in widget[(3 if item == 'sharpy_track' else 4) + idx].value.split(',')]
-                for idx, channel in enumerate(chan_list) if channel in imaged_chan_list
+                channel: []
+                for channel in chan_list
+                if channel in imaged_chan_list
             })
 
         return base_info

--- a/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
@@ -129,8 +129,17 @@ def downsample_and_adjust_contrast(
         size_tuple = (math.floor(image.shape[1] / scale_factor), math.floor(image.shape[0] / scale_factor))
         image = cv2.resize(image, size_tuple)
 
-    if params[contrast_key]:
-        contrast_tuple = tuple(params[contrast_key])
+    contrast_limits = params.get(contrast_key, [])
+    adjust_contrast = params.get(
+        'contrast_adjustment', bool(contrast_limits)
+    )
+    if adjust_contrast:
+        if not contrast_limits:
+            raise ValueError(
+                f"Contrast adjustment is enabled, but no limits were "
+                f"provided for channel '{contrast_key}'."
+            )
+        contrast_tuple = tuple(contrast_limits)
         image = rescale_intensity(image, contrast_tuple)
 
     return image

--- a/test/test_gui_stack_compatibility.py
+++ b/test/test_gui_stack_compatibility.py
@@ -101,3 +101,20 @@ def test_sharpy_cy3_default_matches_direct_stitching():
 
     preprocessing_widget.close()
     stitching_widget.native.close()
+
+
+def test_disabled_rgb_contrast_does_not_parse_limit_fields():
+    preprocessing_widget = preprocessing.PreprocessingWidget()
+    rgb_widget = preprocessing_widget.rgb_widget
+    rgb_widget[3].value = False
+
+    for contrast_widget in rgb_widget[4:]:
+        contrast_widget.value = ""
+
+    rgb_params = preprocessing_widget._get_widget_info(rgb_widget, "rgb")
+
+    assert rgb_params["contrast_adjustment"] is False
+    assert rgb_params["green"] == []
+    assert rgb_params["cy3"] == []
+
+    preprocessing_widget.close()

--- a/test/test_tiff_stack_compatibility.py
+++ b/test/test_tiff_stack_compatibility.py
@@ -152,3 +152,41 @@ def test_downsampling_from_memory_map_matches_fully_loaded_image(tmp_path):
     assert mapped_result.dtype == loaded_result.dtype
     assert mapped_result.shape == loaded_result.shape
     np.testing.assert_array_equal(mapped_result, loaded_result)
+
+
+def test_contrast_adjustment_flag_controls_rescaling():
+    image = np.array([[0, 50, 1000, 2000, 65535]], dtype=np.uint16)
+    params = {
+        "downsampling": 1,
+        "contrast_adjustment": False,
+        "cy3": [50, 2000],
+    }
+
+    unchanged = preprocessing_tools.downsample_and_adjust_contrast(
+        image, params, "downsampling", "cy3"
+    )
+    adjusted = preprocessing_tools.downsample_and_adjust_contrast(
+        image,
+        {**params, "contrast_adjustment": True},
+        "downsampling",
+        "cy3",
+    )
+
+    np.testing.assert_array_equal(unchanged, image)
+    assert not np.array_equal(adjusted, image)
+    assert adjusted[0, 2] > image[0, 2]
+    assert adjusted[0, 3] == np.iinfo(np.uint16).max
+
+
+def test_enabled_contrast_requires_channel_limits():
+    image = np.arange(4, dtype=np.uint16).reshape(2, 2)
+    params = {
+        "downsampling": 1,
+        "contrast_adjustment": True,
+        "green": [],
+    }
+
+    with pytest.raises(ValueError, match="no limits.*green"):
+        preprocessing_tools.downsample_and_adjust_contrast(
+            image, params, "downsampling", "green"
+        )


### PR DESCRIPTION
## Summary

Fix preprocessing so the **Adjust Contrast** checkbox actually controls whether contrast rescaling is performed.

Previously, the checkbox value was stored but ignored by the shared processing helper. Channel contrast fields were also parsed unconditionally, so blank or malformed values could stop preprocessing even when contrast adjustment was disabled.

## Changes

- Honor the `contrast_adjustment` setting during preprocessing.
- Leave image intensities unchanged when contrast adjustment is disabled.
- Parse channel contrast ranges only when adjustment is enabled.
- Store empty ranges for inactive channel fields.
- Raise a clear channel-specific error when contrast is enabled without limits.
- Preserve compatibility with callers that provide contrast limits without the newer boolean setting.
- Add regression tests for processing and GUI parameter handling.

## Validation

- Focused preprocessing and GUI tests: 35 passed.
- Full test suite: 222 passed.
- `git diff --check`: passed.
- `uv lock --check`: passed.

## Scope

This PR only fixes the existing manual contrast behavior. Automatic contrast-range selection will be designed and implemented separately.