### PR TITLE
Feature/automatic contrast range

### DIFF
--- a/src/napari_dmc_brainmap/preprocessing/preprocessing.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing.py
@@ -19,10 +19,29 @@ from napari_dmc_brainmap.utils.params_utils import load_params, clean_params_dic
 from napari_dmc_brainmap.utils.dropdown_utils import get_threshold_dropdown
 from magicgui import magicgui, widgets
 from magicgui.widgets import FunctionGui
-from napari_dmc_brainmap.preprocessing.preprocessing_tools import preprocess_images, create_dirs, get_channels, \
-    chunk_list
+from napari_dmc_brainmap.preprocessing.preprocessing_tools import (
+    AUTOMATIC_RGB_PROFILES,
+    chunk_list,
+    create_dirs,
+    estimate_automatic_rgb_ranges,
+    get_channels,
+    preprocess_images,
+    resolve_automatic_rgb_params,
+)
 from napari_dmc_brainmap.utils.gui_utils import check_input_path
-from typing import List, Dict, Tuple, Union, Optional
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+
+RGB_GUI_CHANNELS = ('cy3', 'green', 'dapi')
+RGB_PROFILE_CHOICES = [
+    (config['label'], profile)
+    for profile, config in AUTOMATIC_RGB_PROFILES.items()
+]
+RGB_DEFAULT_PROFILES = {
+    'cy3': 'preserve_strong_signal_probe',
+    'green': 'balanced_cells',
+    'dapi': 'balanced_cells',
+}
 
 
 @thread_worker(progress={"total": 100})
@@ -52,6 +71,10 @@ def do_preprocessing(
         str: Animal ID for which preprocessing was performed.
     """
     if "operations" in preprocessing_params.keys():
+        if 'rgb' in preprocessing_params['operations']:
+            resolve_automatic_rgb_params(
+                input_path, img_list, preprocessing_params
+            )
         resolution_tuple = tuple(resolution) if 'sharpy_track' in preprocessing_params['operations'] else False
         num_cores = os.cpu_count()
         # overwrite parallelization to 1 if detects Darwin OS
@@ -77,6 +100,29 @@ def do_preprocessing(
 
     yield 100
     return get_animal_id(input_path)
+
+
+@thread_worker
+def estimate_rgb_ranges_worker(
+    input_path: Path,
+    image_names: List[str],
+    source_channels: List[str],
+    target_profiles: Dict[str, str],
+    calibration_key: Tuple,
+    progress_callback: Callable[[object], None],
+) -> Tuple[Tuple, Dict[str, object]]:
+    """Estimate RGB ranges without blocking the napari user interface."""
+    def report_progress(report: Dict[str, object]) -> None:
+        progress_callback((calibration_key, report))
+
+    calibration = estimate_automatic_rgb_ranges(
+        input_path,
+        image_names,
+        source_channels,
+        target_profiles,
+        progress_callback=report_progress,
+    )
+    return calibration_key, calibration
 
 
 def create_general_widget(
@@ -163,6 +209,154 @@ def create_general_widget(
     return container
 
 
+def create_rgb_widget() -> widgets.Container:
+    """Create RGB-specific controls with manual and automatic contrast modes."""
+    contrast_limits = {
+        'dapi': '50,2000',
+        'green': '50,1000',
+        'cy3': '50,2000',
+    }
+    container = widgets.Container(
+        widgets=[
+            widgets.CheckBox(
+                name='process_rgb',
+                value=False,
+                label='Process RGB',
+                tooltip='Tick to create RGB images.',
+            ),
+            widgets.SpinBox(
+                name='downsampling',
+                value=3,
+                min=1,
+                label='Downsampling Factor',
+                tooltip='Enter scale factor for downsampling.',
+            ),
+            widgets.ComboBox(
+                name='contrast_mode',
+                choices=[
+                    ('Manual', 'manual'),
+                    ('Automatic', 'automatic'),
+                    ('None', 'none'),
+                ],
+                value='manual',
+                label='Contrast mode',
+            ),
+            widgets.Label(
+                name='automatic_method_note',
+                value=(
+                    'Black padding is ignored; each section contributes '
+                    'equally.'
+                ),
+                label='',
+            ),
+        ],
+        labels=True,
+    )
+
+    for channel in RGB_GUI_CHANNELS:
+        selected = channel in ('cy3', 'green')
+        row = widgets.Container(
+            name=f'{channel}_row',
+            layout='horizontal',
+            labels=True,
+            widgets=[
+                widgets.CheckBox(
+                    name=f'{channel}_enabled',
+                    value=selected,
+                    label=channel.upper() if channel == 'dapi' else channel.capitalize(),
+                ),
+                widgets.LineEdit(
+                    name=f'{channel}_manual_range',
+                    value=contrast_limits[channel],
+                    label='Range',
+                    tooltip=f'Enter manual min,max limits for {channel}.',
+                ),
+                widgets.ComboBox(
+                    name=f'{channel}_profile',
+                    choices=RGB_PROFILE_CHOICES,
+                    value=RGB_DEFAULT_PROFILES[channel],
+                    label='Profile',
+                    tooltip=(
+                        'Balanced (cells) clips both histogram tails. '
+                        'Preserve strong signal (probe) protects rare bright '
+                        'sections.'
+                    ),
+                ),
+                widgets.LineEdit(
+                    name=f'{channel}_estimated_range',
+                    value='Not estimated',
+                    label='Estimated range',
+                    enabled=False,
+                ),
+                widgets.LineEdit(
+                    name=f'{channel}_clipped',
+                    value='—',
+                    label='Clipped low / high',
+                    enabled=False,
+                ),
+            ],
+        )
+        container.append(row)
+
+    container.append(
+        widgets.PushButton(
+            name='estimate_ranges',
+            text='Estimate ranges',
+        )
+    )
+    container.append(
+        widgets.ProgressBar(
+            name='estimation_progress',
+            min=0,
+            max=1,
+            value=0,
+            label='Estimate progress',
+        )
+    )
+    update_rgb_widget_state(container)
+    return container
+
+
+def update_rgb_widget_state(widget: widgets.Container) -> None:
+    """Show and enable RGB controls that apply to the current mode."""
+    mode = widget['contrast_mode'].value
+    widget['automatic_method_note'].visible = mode == 'automatic'
+    any_selected = False
+    for channel in RGB_GUI_CHANNELS:
+        row = widget[f'{channel}_row']
+        enabled_widget = row[f'{channel}_enabled']
+        selected = enabled_widget.enabled and enabled_widget.value
+        any_selected |= selected
+        manual_range = row[f'{channel}_manual_range']
+        profile = row[f'{channel}_profile']
+        estimated_range = row[f'{channel}_estimated_range']
+        clipped = row[f'{channel}_clipped']
+
+        manual_range.visible = mode == 'manual'
+        manual_range.enabled = mode == 'manual' and selected
+        profile.visible = mode == 'automatic'
+        profile.enabled = mode == 'automatic' and selected
+        estimated_range.visible = mode == 'automatic'
+        clipped.visible = mode == 'automatic'
+
+        if not selected:
+            if estimated_range.value != 'Not selected':
+                estimated_range._automatic_value = estimated_range.value
+                clipped._automatic_value = clipped.value
+            estimated_range.value = 'Not selected'
+            clipped.value = '—'
+        elif estimated_range.value == 'Not selected':
+            estimated_range.value = getattr(
+                estimated_range, '_automatic_value', 'Not estimated'
+            )
+            clipped.value = getattr(clipped, '_automatic_value', '—')
+
+    estimate_button = widget['estimate_ranges']
+    estimate_button.visible = mode == 'automatic'
+    estimate_button.enabled = mode == 'automatic' and any_selected
+    widget['estimation_progress'].visible = mode == 'automatic'
+
+
 def initialize_header_widget() -> FunctionGui:
     """
     Initialize a header widget for selecting the input path and imaged channels.
@@ -201,6 +395,8 @@ class PreprocessingWidget(QWidget):
     """
     progress_signal = Signal(int)
     """Signal emitted to update the progress bar with an integer value."""
+    rgb_estimation_progress_signal = Signal(object)
+    """Signal carrying automatic RGB calibration progress to the GUI."""
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         """
@@ -211,13 +407,17 @@ class PreprocessingWidget(QWidget):
         """
         super().__init__(parent)
         self.setLayout(QVBoxLayout())
+        self._rgb_calibration = None
+        self._rgb_calibration_key = None
+        self._rgb_imaged_channels = set()
+        self._rgb_estimation_worker = None
 
         # Header widget
         self.header = initialize_header_widget()
         self.header.native.layout().setSizeConstraint(QVBoxLayout.SetFixedSize)
 
         # Add generalized widgets for different operations
-        self.rgb_widget = create_general_widget('RGB', ['dapi', 'green', 'cy3'])
+        self.rgb_widget = create_rgb_widget()
         self.sharpy_widget = create_general_widget('SHARPy', ['dapi', 'green', 'n3', 'cy3', 'cy5'], contrast_limits={
             'dapi': '50,1000',
             'green': '50,300',
@@ -249,6 +449,27 @@ class PreprocessingWidget(QWidget):
         self.layout().addWidget(self.btn)
         self.layout().addWidget(self.progress_bar)
         self.progress_signal.connect(self.progress_bar.setValue)
+        self.rgb_estimation_progress_signal.connect(
+            self._update_rgb_estimation_progress
+        )
+
+        self.header.input_path.changed.connect(self._rgb_settings_changed)
+        self.header.chans_imaged.changed.connect(self._sync_rgb_channels)
+        self.rgb_widget['contrast_mode'].changed.connect(
+            self._rgb_settings_changed
+        )
+        self.rgb_widget['estimate_ranges'].clicked.connect(
+            self._estimate_rgb_ranges
+        )
+        for channel in RGB_GUI_CHANNELS:
+            row = self.rgb_widget[f'{channel}_row']
+            row[f'{channel}_enabled'].changed.connect(
+                self._rgb_settings_changed
+            )
+            row[f'{channel}_profile'].changed.connect(
+                self._rgb_settings_changed
+            )
+        self._sync_rgb_channels()
 
     def _add_gui_section(self, name: str, widget: FunctionGui) -> None:
         """
@@ -262,6 +483,219 @@ class PreprocessingWidget(QWidget):
         collapsible.addWidget(widget.native)
         self.layout().addWidget(collapsible)
 
+    def _selected_rgb_profiles(self) -> Dict[str, str]:
+        """Return automatic profiles for enabled and imaged RGB channels."""
+        profiles = {}
+        for channel in RGB_GUI_CHANNELS:
+            row = self.rgb_widget[f'{channel}_row']
+            enabled_widget = row[f'{channel}_enabled']
+            if enabled_widget.enabled and enabled_widget.value:
+                profiles[channel] = row[f'{channel}_profile'].value
+        return profiles
+
+    def _current_rgb_calibration_key(self) -> Tuple:
+        """Return the GUI state that determines automatic calibration."""
+        return (
+            str(self.header.input_path.value),
+            tuple(self.header.chans_imaged.value),
+            tuple(self._selected_rgb_profiles().items()),
+        )
+
+    def _clear_rgb_calibration_display(self) -> None:
+        """Clear automatic results after an input or profile change."""
+        for channel in RGB_GUI_CHANNELS:
+            row = self.rgb_widget[f'{channel}_row']
+            estimated_range = row[f'{channel}_estimated_range']
+            clipped = row[f'{channel}_clipped']
+            estimated_range._automatic_value = 'Not estimated'
+            clipped._automatic_value = '—'
+            if row[f'{channel}_enabled'].value:
+                estimated_range.value = 'Not estimated'
+                clipped.value = '—'
+
+        self.rgb_widget['estimation_progress'].value = 0
+
+    def _rgb_settings_changed(self, *_args) -> None:
+        """Invalidate cached calibration and refresh conditional controls."""
+        self._rgb_calibration = None
+        self._rgb_calibration_key = None
+        self._clear_rgb_calibration_display()
+        update_rgb_widget_state(self.rgb_widget)
+
+    def _sync_rgb_channels(self, *_args) -> None:
+        """Synchronize RGB checkboxes with channels declared as imaged."""
+        imaged_channels = set(self.header.chans_imaged.value)
+        newly_imaged = imaged_channels - self._rgb_imaged_channels
+        for channel in RGB_GUI_CHANNELS:
+            enabled_widget = self.rgb_widget[f'{channel}_row'][
+                f'{channel}_enabled'
+            ]
+            is_imaged = channel in imaged_channels
+            enabled_widget.enabled = is_imaged
+            if not is_imaged:
+                enabled_widget.value = False
+            elif channel in newly_imaged:
+                enabled_widget.value = True
+        self._rgb_imaged_channels = imaged_channels
+        self._rgb_settings_changed()
+
+    def _estimate_rgb_ranges(self, *_args) -> None:
+        """Start an asynchronous preview of automatic RGB ranges."""
+        input_path = self.header.input_path.value
+        if not check_input_path(input_path):
+            return
+        profiles = self._selected_rgb_profiles()
+        if not profiles:
+            show_info("Select at least one RGB channel to estimate ranges.")
+            return
+        source_channels = list(self.header.chans_imaged.value)
+        image_names = get_image_list(input_path, next(iter(profiles)))
+        calibration_key = self._current_rgb_calibration_key()
+
+        estimate_button = self.rgb_widget['estimate_ranges']
+        estimate_button.text = 'Estimating ranges...'
+        estimate_button.enabled = False
+        progress = self.rgb_widget['estimation_progress']
+        progress.min = 0
+        progress.max = max(len(image_names), 1)
+        progress.value = 0
+        print(
+            '[Automatic RGB contrast] Starting calibration for '
+            f'{len(image_names)} sections. '
+            f"Channels: {', '.join(profiles)}",
+            flush=True,
+        )
+        worker = estimate_rgb_ranges_worker(
+            input_path,
+            image_names,
+            source_channels,
+            profiles,
+            calibration_key,
+            self.rgb_estimation_progress_signal.emit,
+        )
+        worker.returned.connect(self._apply_rgb_calibration)
+        worker.errored.connect(self._show_rgb_calibration_error)
+        self._rgb_estimation_worker = worker
+        worker.start()
+
+    def _update_rgb_estimation_progress(
+        self, result: Tuple[Tuple, Dict[str, object]]
+    ) -> None:
+        """Append one section's histogram cutoffs to the live report."""
+        calibration_key, report = result
+        if calibration_key != self._current_rgb_calibration_key():
+            return
+
+        progress = self.rgb_widget['estimation_progress']
+        event = report['event']
+        if event == 'section':
+            section_index = report['section_index']
+            total_sections = report['total_sections']
+            progress.max = max(total_sections, 1)
+            progress.value = section_index
+            self.rgb_widget['estimate_ranges'].text = (
+                f'Estimating {section_index}/{total_sections}...'
+            )
+            if report['status'] == 'skipped_all_black':
+                line = (
+                    f"[{section_index}/{total_sections}] "
+                    f"{report['image_name']}: skipped (all black)"
+                )
+            else:
+                cutoffs = ', '.join(
+                    f'{channel}={limits[0]}–{limits[1]}'
+                    for channel, limits in report[
+                        'channel_cutoffs'
+                    ].items()
+                )
+                padding_percent = report['padding_fraction'] * 100
+                line = (
+                    f"[{section_index}/{total_sections}] "
+                    f"{report['image_name']}: {cutoffs}; "
+                    f'padding excluded={padding_percent:.2f}%'
+                )
+        else:
+            ranges = ', '.join(
+                f'{channel}={limits[0]}–{limits[1]}'
+                for channel, limits in report['automatic_ranges'].items()
+            )
+            line = f'Complete. Dataset ranges: {ranges}'
+
+        print(f'[Automatic RGB contrast] {line}', flush=True)
+
+    def _apply_rgb_calibration(
+        self, result: Tuple[Tuple, Dict[str, object]]
+    ) -> None:
+        """Display automatic ranges if the relevant GUI state is unchanged."""
+        calibration_key, calibration = result
+        if calibration_key == self._current_rgb_calibration_key():
+            self._rgb_calibration_key = calibration_key
+            self._rgb_calibration = calibration
+            for channel, limits in calibration['automatic_ranges'].items():
+                row = self.rgb_widget[f'{channel}_row']
+                range_text = f'{limits[0]} – {limits[1]}'
+                clipped_values = calibration[
+                    'automatic_clipped_percent'
+                ][channel]
+                clipped_text = (
+                    f"{clipped_values['low']:.3f}% / "
+                    f"{clipped_values['high']:.3f}%"
+                )
+                row[f'{channel}_estimated_range']._automatic_value = (
+                    range_text
+                )
+                row[f'{channel}_clipped']._automatic_value = clipped_text
+                row[f'{channel}_estimated_range'].value = range_text
+                row[f'{channel}_clipped'].value = clipped_text
+        estimate_button = self.rgb_widget['estimate_ranges']
+        estimate_button.text = 'Estimate ranges'
+        update_rgb_widget_state(self.rgb_widget)
+
+    def _show_rgb_calibration_error(self, error: Exception) -> None:
+        """Report automatic calibration errors and restore the button."""
+        show_info(f"Could not estimate automatic RGB ranges: {error}")
+        print(f'[Automatic RGB contrast] Error: {error}', flush=True)
+        estimate_button = self.rgb_widget['estimate_ranges']
+        estimate_button.text = 'Estimate ranges'
+        update_rgb_widget_state(self.rgb_widget)
+
+    def _get_rgb_widget_info(self) -> Dict[str, object]:
+        """Collect RGB mode, channel, profile, and range parameters."""
+        profiles = self._selected_rgb_profiles()
+        channels = list(profiles)
+        mode = self.rgb_widget['contrast_mode'].value
+        rgb_info = {
+            'channels': channels,
+            'downsampling': self.rgb_widget['downsampling'].value,
+            'contrast_mode': mode,
+            'contrast_adjustment': mode != 'none',
+        }
+
+        if mode == 'manual':
+            for channel in channels:
+                value = self.rgb_widget[f'{channel}_row'][
+                    f'{channel}_manual_range'
+                ].value
+                rgb_info[channel] = [int(item) for item in value.split(',')]
+        elif mode == 'automatic':
+            rgb_info['automatic_profiles'] = profiles
+            for channel in channels:
+                rgb_info[channel] = []
+            if (
+                self._rgb_calibration is not None
+                and self._rgb_calibration_key
+                == self._current_rgb_calibration_key()
+            ):
+                rgb_info.update(self._rgb_calibration)
+                for channel, limits in self._rgb_calibration[
+                    'automatic_ranges'
+                ].items():
+                    rgb_info[channel] = list(limits)
+        else:
+            for channel in channels:
+                rgb_info[channel] = []
+        return rgb_info
+
     def _get_widget_info(self, widget: FunctionGui, item: str) -> Dict[str, Union[List[int], int, str]]:
         """
         Retrieve information from a given widget based on the type of item.
@@ -273,7 +707,10 @@ class PreprocessingWidget(QWidget):
         Returns:
             Dict[str, Union[List[int], int, str]]: Information extracted from the widget.
         """
-        chan_list = ['dapi', 'green', 'cy3'] if item == 'rgb' else ['dapi', 'green', 'n3', 'cy3', 'cy5']
+        if item == 'rgb':
+            return self._get_rgb_widget_info()
+
+        chan_list = ['dapi', 'green', 'n3', 'cy3', 'cy5']
 
         imaged_chan_list = (widget[1].value if 'all' not in widget[1].value
                             else self.header.chans_imaged.value)
@@ -418,10 +855,18 @@ class PreprocessingWidget(QWidget):
 
         # Retrieve preprocessing parameters
         preprocessing_params = self._get_preprocessing_params()
+        if (
+            preprocessing_params.get('operations', {}).get('rgb')
+            and not preprocessing_params['rgb_params']['channels']
+        ):
+            show_info("Select at least one channel for RGB preprocessing.")
+            return
         save_dirs = create_dirs(preprocessing_params, input_path)
         channels = get_channels(preprocessing_params)
-        for chan in channels:
-            img_list = get_image_list(input_path, chan)
+        if not channels:
+            show_info("Select at least one channel for preprocessing.")
+            return
+        img_list = get_image_list(input_path, channels[0])
         params_dict = load_params(input_path)
         resolution = params_dict['atlas_info']['resolution']
 

--- a/src/napari_dmc_brainmap/preprocessing/preprocessing.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing.py
@@ -94,7 +94,11 @@ def do_preprocessing(
             yield int(progress_value)
 
         preprocessing_params = clean_params_dict(preprocessing_params, "operations")
-        update_params_dict(input_path, preprocessing_params)
+        update_params_dict(
+            input_path,
+            preprocessing_params,
+            replace_sections=('rgb_params',),
+        )
     else:
         show_info("No preprocessing operations selected. Expand the respective windows and tick the checkbox.")
 

--- a/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
+++ b/src/napari_dmc_brainmap/preprocessing/preprocessing_tools.py
@@ -7,7 +7,32 @@ from skimage.exposure import rescale_intensity
 import tifffile
 from napari.utils.notifications import show_info
 from napari_dmc_brainmap.utils.path_utils import get_info
-from typing import Dict, List, Union, Tuple
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+
+RGB_CHANNELS = ('cy3', 'green', 'dapi')
+AUTOMATIC_RGB_PROFILES = {
+    'balanced_cells': {
+        'label': 'Balanced (cells)',
+        'low_clip_fraction': 0.00175,
+        'high_clip_fraction': 0.00175,
+    },
+    'preserve_strong_signal_probe': {
+        'label': 'Preserve strong signal (probe)',
+        'low_clip_fraction': 0.00175,
+        'section_high_quantile': 0.9999,
+        'dataset_high_quantile': 0.99,
+    },
+}
 
 
 def chunk_list(input_list: List[str], chunk_size: int = 4) -> List[List[str]]:
@@ -68,7 +93,7 @@ def get_channels(params: Dict[str, Union[str, dict]]) -> List[str]:
         operation_list = list(params['operations'].keys())
         for operation in operation_list:
             channels.extend(params[f"{operation}_params"]["channels"])
-    return list(set(channels))
+    return list(dict.fromkeys(channels))
 
 
 def load_stitched_images(input_path: Union[str, Path], chan: str, image: str) -> Union[np.ndarray, bool]:
@@ -104,6 +129,319 @@ def load_stitched_images(input_path: Union[str, Path], chan: str, image: str) ->
     except Exception as e:
         print(f"[INFO] OpenCV failed: {e}\nFalling back to tifffile...")
         return tifffile.imread(im_fn)
+
+
+def find_shared_content_bounds(
+    images: Sequence[np.ndarray],
+) -> Union[Tuple[slice, slice], None]:
+    """Return the bounding box outside shared all-channel black padding."""
+    if not images:
+        return None
+
+    shape = images[0].shape
+    if len(shape) != 2:
+        raise ValueError(f"Expected a 2D stitched image, got shape {shape}")
+
+    row_has_data = np.zeros(shape[0], dtype=bool)
+    column_has_data = np.zeros(shape[1], dtype=bool)
+    for image in images:
+        if image.shape != shape:
+            raise ValueError(
+                "All channels for a section must have the same shape; "
+                f"found {shape} and {image.shape}."
+            )
+        nonzero = image != 0
+        if np.issubdtype(image.dtype, np.floating):
+            nonzero &= np.isfinite(image)
+        row_has_data |= np.any(nonzero, axis=1)
+        column_has_data |= np.any(nonzero, axis=0)
+
+    rows = np.flatnonzero(row_has_data)
+    columns = np.flatnonzero(column_has_data)
+    if not rows.size or not columns.size:
+        return None
+    return (
+        slice(int(rows[0]), int(rows[-1]) + 1),
+        slice(int(columns[0]), int(columns[-1]) + 1),
+    )
+
+
+def image_histogram(
+    image: np.ndarray,
+    bounds: Tuple[slice, slice],
+    chunk_rows: int = 512,
+) -> np.ndarray:
+    """Calculate an exact uint8/uint16 histogram inside ``bounds``."""
+    if image.dtype not in (np.dtype('uint8'), np.dtype('uint16')):
+        raise TypeError(
+            "Automatic RGB contrast supports uint8 and uint16 stitched "
+            f"images, not {image.dtype}."
+        )
+
+    row_slice, column_slice = bounds
+    row_start = 0 if row_slice.start is None else row_slice.start
+    row_stop = image.shape[0] if row_slice.stop is None else row_slice.stop
+    histogram = np.zeros(65536, dtype=np.uint64)
+    for start in range(row_start, row_stop, chunk_rows):
+        stop = min(start + chunk_rows, row_stop)
+        chunk = np.asarray(image[start:stop, column_slice]).reshape(-1)
+        histogram += np.bincount(chunk, minlength=65536).astype(
+            np.uint64, copy=False
+        )
+    return histogram
+
+
+def histogram_quantile(histogram: np.ndarray, quantile: float) -> int:
+    """Return an inverse-CDF quantile from histogram counts or weights."""
+    if not 0 <= quantile <= 1:
+        raise ValueError(f"Quantile must be in [0, 1], got {quantile}.")
+    total = float(histogram.sum())
+    if total <= 0:
+        raise ValueError("Cannot estimate contrast from an empty histogram.")
+    cumulative = np.cumsum(histogram, dtype=np.float64)
+    if quantile == 1:
+        return int(np.flatnonzero(histogram > 0)[-1])
+    return int(
+        np.searchsorted(cumulative, quantile * total, side='right')
+    )
+
+
+def average_normalized_histograms(
+    histograms: Sequence[np.ndarray],
+) -> np.ndarray:
+    """Combine histograms while giving every eligible section equal weight."""
+    if not histograms:
+        raise ValueError("At least one section histogram is required.")
+    combined = np.zeros(65536, dtype=np.float64)
+    for histogram in histograms:
+        total = float(histogram.sum())
+        if total > 0:
+            combined += histogram / total
+    total = combined.sum()
+    if total <= 0:
+        raise ValueError("All section histograms are empty.")
+    return combined / total
+
+
+def _stable_histogram_range(
+    histogram: np.ndarray,
+    low: int,
+    high: int,
+) -> List[int]:
+    """Return a non-degenerate integer range supported by the histogram."""
+    if high > low:
+        return [low, high]
+    occupied = np.flatnonzero(histogram > 0)
+    if occupied.size > 1:
+        return [int(occupied[0]), int(occupied[-1])]
+    value = int(occupied[0]) if occupied.size else 0
+    return [value, value + 1] if value < 65535 else [65534, 65535]
+
+
+def estimate_automatic_rgb_ranges(
+    input_path: Union[str, Path],
+    image_names: Sequence[str],
+    source_channels: Sequence[str],
+    target_profiles: Mapping[str, str],
+    progress_callback: Optional[Callable[[Dict[str, object]], None]] = None,
+) -> Dict[str, object]:
+    """Estimate one reproducible automatic contrast range per RGB channel."""
+    source_channels = list(dict.fromkeys(source_channels))
+    if not source_channels:
+        raise ValueError("At least one imaged source channel is required.")
+    if not image_names:
+        raise ValueError("No stitched images were found for calibration.")
+
+    unknown_channels = set(target_profiles) - set(RGB_CHANNELS)
+    if unknown_channels:
+        raise ValueError(
+            f"Unsupported RGB channels: {sorted(unknown_channels)}"
+        )
+    missing_sources = set(target_profiles) - set(source_channels)
+    if missing_sources:
+        raise ValueError(
+            "Automatic RGB channels must be present in imaged channels: "
+            f"{sorted(missing_sources)}"
+        )
+    for channel, profile in target_profiles.items():
+        if profile not in AUTOMATIC_RGB_PROFILES:
+            raise ValueError(
+                f"Unknown automatic profile {profile!r} for {channel}."
+            )
+
+    combined_histograms = {
+        channel: np.zeros(65536, dtype=np.float64)
+        for channel in target_profiles
+    }
+    sections_used = {channel: 0 for channel in target_profiles}
+    section_highs = {channel: [] for channel in target_profiles}
+    padding_fractions = []
+
+    total_sections = len(image_names)
+    for section_index, image_name in enumerate(image_names, start=1):
+        images = {
+            channel: load_stitched_images(input_path, channel, image_name)
+            for channel in source_channels
+        }
+        bounds = find_shared_content_bounds(list(images.values()))
+        if bounds is None:
+            if progress_callback is not None:
+                progress_callback(
+                    {
+                        'event': 'section',
+                        'section_index': section_index,
+                        'total_sections': total_sections,
+                        'image_name': image_name,
+                        'status': 'skipped_all_black',
+                        'padding_fraction': 1.0,
+                        'channel_cutoffs': {},
+                    }
+                )
+            continue
+
+        shape = next(iter(images.values())).shape
+        valid_area = (
+            (bounds[0].stop - bounds[0].start)
+            * (bounds[1].stop - bounds[1].start)
+        )
+        padding_fraction = 1.0 - valid_area / np.prod(shape)
+        padding_fractions.append(padding_fraction)
+        channel_cutoffs = {}
+
+        for channel, profile in target_profiles.items():
+            histogram = image_histogram(images[channel], bounds)
+            if not histogram.sum():
+                continue
+            combined_histograms[channel] += histogram / histogram.sum()
+            sections_used[channel] += 1
+            profile_config = AUTOMATIC_RGB_PROFILES[profile]
+            section_low = histogram_quantile(
+                histogram, profile_config['low_clip_fraction']
+            )
+            if profile == 'preserve_strong_signal_probe':
+                section_high = histogram_quantile(
+                    histogram,
+                    profile_config['section_high_quantile'],
+                )
+                section_highs[channel].append(section_high)
+            else:
+                section_high = histogram_quantile(
+                    histogram,
+                    1.0 - profile_config['high_clip_fraction'],
+                )
+            channel_cutoffs[channel] = _stable_histogram_range(
+                histogram, section_low, section_high
+            )
+
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    'event': 'section',
+                    'section_index': section_index,
+                    'total_sections': total_sections,
+                    'image_name': image_name,
+                    'status': 'processed',
+                    'padding_fraction': float(padding_fraction),
+                    'channel_cutoffs': channel_cutoffs,
+                }
+            )
+
+    ranges = {}
+    clipped_percent = {}
+    for channel, profile in target_profiles.items():
+        if not sections_used[channel]:
+            raise ValueError(
+                f"No valid histogram pixels were found for {channel}."
+            )
+        combined = combined_histograms[channel] / sections_used[channel]
+        profile_config = AUTOMATIC_RGB_PROFILES[profile]
+        low = histogram_quantile(
+            combined, profile_config['low_clip_fraction']
+        )
+        if profile == 'balanced_cells':
+            high = histogram_quantile(
+                combined, 1.0 - profile_config['high_clip_fraction']
+            )
+        else:
+            high = int(
+                np.quantile(
+                    section_highs[channel],
+                    profile_config['dataset_high_quantile'],
+                    method='higher',
+                )
+            )
+        low, high = _stable_histogram_range(combined, low, high)
+        ranges[channel] = [low, high]
+        total = combined.sum()
+        clipped_percent[channel] = {
+            'low': float(combined[:low].sum() / total * 100),
+            'high': float(combined[high + 1:].sum() / total * 100),
+        }
+    calibration = {
+        'automatic_ranges': ranges,
+        'automatic_profiles': dict(target_profiles),
+        'automatic_clipped_percent': clipped_percent,
+        'automatic_calibration': {
+            'method': 'equal_section_histogram',
+            'padding_exclusion': 'shared_all_channel_black_border',
+            'source_channels': source_channels,
+            'sections_requested': len(image_names),
+            'sections_used': sections_used,
+            'mean_padding_fraction': (
+                float(np.mean(padding_fractions))
+                if padding_fractions else 0.0
+            ),
+        },
+    }
+    if progress_callback is not None:
+        progress_callback(
+            {
+                'event': 'complete',
+                'section_index': total_sections,
+                'total_sections': total_sections,
+                'automatic_ranges': ranges,
+            }
+        )
+    return calibration
+
+
+def resolve_automatic_rgb_params(
+    input_path: Union[str, Path],
+    image_names: Sequence[str],
+    params: Dict[str, object],
+) -> Dict[str, object]:
+    """Populate automatic ranges in RGB parameters when they are not cached."""
+    rgb_params = params['rgb_params']
+    if rgb_params.get('contrast_mode') != 'automatic':
+        return {}
+
+    channels = rgb_params['channels']
+    profiles = rgb_params['automatic_profiles']
+    ranges = rgb_params.get('automatic_ranges', {})
+    if not all(channel in ranges for channel in channels):
+        calibration = estimate_automatic_rgb_ranges(
+            input_path,
+            image_names,
+            params['general']['chans_imaged'],
+            {channel: profiles[channel] for channel in channels},
+        )
+        rgb_params.update(calibration)
+    else:
+        calibration = {
+            key: rgb_params[key]
+            for key in (
+                'automatic_ranges',
+                'automatic_profiles',
+                'automatic_clipped_percent',
+                'automatic_calibration',
+            )
+            if key in rgb_params
+        }
+
+    for channel in channels:
+        rgb_params[channel] = list(rgb_params['automatic_ranges'][channel])
+    rgb_params['contrast_adjustment'] = True
+    return calibration
 
 
 def downsample_and_adjust_contrast(

--- a/src/napari_dmc_brainmap/utils/params_utils.py
+++ b/src/napari_dmc_brainmap/utils/params_utils.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from typing import Dict
+from typing import Dict, Sequence
 from mergedeep import merge
 from napari.utils.notifications import show_info
 
@@ -76,7 +76,12 @@ def clean_params_dict(params_dict: Dict, key: str) -> Dict:
     return params_dict
 
 
-def update_params_dict(input_path: pathlib.Path, params_dict: Dict, create: bool = False) -> Dict:
+def update_params_dict(
+    input_path: pathlib.Path,
+    params_dict: Dict,
+    create: bool = False,
+    replace_sections: Sequence[str] = (),
+) -> Dict:
     """
     Update the `params.json` file with the specified dictionary.
 
@@ -84,6 +89,9 @@ def update_params_dict(input_path: pathlib.Path, params_dict: Dict, create: bool
         input_path (pathlib.Path): Path to the directory where `params.json` should be located.
         params_dict (Dict): The dictionary to update the `params.json` file with.
         create (bool, optional): Whether to create the `params.json` file if it does not exist. Defaults to False.
+        replace_sections (Sequence[str], optional): Top-level sections to
+            replace instead of deep-merging. Sections absent from
+            ``params_dict`` are left unchanged.
 
     Returns:
         Dict: The updated params dictionary.
@@ -103,6 +111,9 @@ def update_params_dict(input_path: pathlib.Path, params_dict: Dict, create: bool
         show_info("params.json exists -- overriding existing values")
         with open(params_fn) as fn:
             params_dict_old = json.load(fn)
+        for section in replace_sections:
+            if section in params_dict:
+                params_dict_old.pop(section, None)
         params_dict_new = merge(params_dict_old, params_dict)
 
         with open(params_fn, 'w') as fn:

--- a/test/test_automatic_rgb_contrast.py
+++ b/test/test_automatic_rgb_contrast.py
@@ -1,0 +1,152 @@
+import json
+
+import numpy as np
+import pytest
+import tifffile
+
+from napari_dmc_brainmap.preprocessing import preprocessing_tools
+
+
+def _write_section(root, channel, name, image):
+    channel_dir = root / "stitched" / channel
+    channel_dir.mkdir(parents=True, exist_ok=True)
+    tifffile.imwrite(
+        channel_dir / f"{name}_stitched.tif",
+        image,
+        photometric="minisblack",
+    )
+
+
+def test_shared_bounds_use_all_channels_and_keep_internal_zeros():
+    sparse_signal = np.zeros((8, 10), dtype=np.uint16)
+    sparse_signal[4, 5] = 5000
+    structural = np.zeros_like(sparse_signal)
+    structural[2:7, 3:9] = 100
+
+    bounds = preprocessing_tools.find_shared_content_bounds(
+        [sparse_signal, structural]
+    )
+    histogram = preprocessing_tools.image_histogram(sparse_signal, bounds)
+
+    assert bounds == (slice(2, 7), slice(3, 9))
+    assert histogram.sum() == 30
+    assert histogram[0] == 29
+    assert histogram[5000] == 1
+
+
+def test_section_histograms_are_combined_with_equal_weight():
+    small_section = np.zeros(65536, dtype=np.uint64)
+    large_section = np.zeros(65536, dtype=np.uint64)
+    small_section[100] = 10
+    large_section[1000] = 1000
+
+    combined = preprocessing_tools.average_normalized_histograms(
+        [small_section, large_section]
+    )
+
+    assert combined[100] == pytest.approx(0.5)
+    assert combined[1000] == pytest.approx(0.5)
+    assert combined.sum() == pytest.approx(1.0)
+
+
+def test_automatic_profiles_estimate_dataset_wide_ranges(tmp_path):
+    image_names = ["section_1", "section_2", "section_3"]
+    progress_reports = []
+    for section_index, image_name in enumerate(image_names):
+        green = np.zeros((12, 12), dtype=np.uint16)
+        green[1:11, 1:11] = np.arange(100, 200, dtype=np.uint16).reshape(
+            10, 10
+        )
+        cy3 = np.zeros_like(green)
+        cy3[1:11, 1:11] = 50
+        if section_index == 0:
+            cy3[5, 5] = 60000
+        _write_section(tmp_path, "green", image_name, green)
+        _write_section(tmp_path, "cy3", image_name, cy3)
+
+    calibration = preprocessing_tools.estimate_automatic_rgb_ranges(
+        tmp_path,
+        image_names,
+        source_channels=["green", "cy3"],
+        target_profiles={
+            "green": "balanced_cells",
+            "cy3": "preserve_strong_signal_probe",
+        },
+        progress_callback=progress_reports.append,
+    )
+
+    assert calibration["automatic_ranges"]["green"] == [100, 199]
+    assert calibration["automatic_ranges"]["cy3"] == [50, 60000]
+    assert calibration["automatic_calibration"]["sections_used"] == {
+        "green": 3,
+        "cy3": 3,
+    }
+    assert calibration["automatic_calibration"][
+        "mean_padding_fraction"
+    ] == pytest.approx(1 - 100 / 144)
+    assert len(progress_reports) == 4
+    assert progress_reports[0] == {
+        "event": "section",
+        "section_index": 1,
+        "total_sections": 3,
+        "image_name": "section_1",
+        "status": "processed",
+        "padding_fraction": pytest.approx(1 - 100 / 144),
+        "channel_cutoffs": {
+            "green": [100, 199],
+            "cy3": [50, 60000],
+        },
+    }
+    assert progress_reports[-1] == {
+        "event": "complete",
+        "section_index": 3,
+        "total_sections": 3,
+        "automatic_ranges": {
+            "green": [100, 199],
+            "cy3": [50, 60000],
+        },
+    }
+
+
+def test_resolved_ranges_are_json_serializable_and_reused(tmp_path, monkeypatch):
+    image = np.zeros((6, 6), dtype=np.uint16)
+    image[1:5, 1:5] = np.arange(16, dtype=np.uint16).reshape(4, 4) + 100
+    _write_section(tmp_path, "green", "section_1", image)
+    params = {
+        "general": {"chans_imaged": ["green"]},
+        "rgb_params": {
+            "channels": ["green"],
+            "contrast_mode": "automatic",
+            "contrast_adjustment": True,
+            "automatic_profiles": {"green": "balanced_cells"},
+            "green": [],
+        },
+    }
+
+    preprocessing_tools.resolve_automatic_rgb_params(
+        tmp_path, ["section_1"], params
+    )
+    resolved = params["rgb_params"]["green"]
+    json.dumps(params)
+
+    monkeypatch.setattr(
+        preprocessing_tools,
+        "estimate_automatic_rgb_ranges",
+        lambda *_args, **_kwargs: pytest.fail("cached range was not reused"),
+    )
+    preprocessing_tools.resolve_automatic_rgb_params(
+        tmp_path, ["section_1"], params
+    )
+
+    assert resolved == [100, 115]
+    assert params["rgb_params"]["automatic_ranges"]["green"] == resolved
+
+
+def test_automatic_contrast_rejects_unknown_profile(tmp_path):
+    with pytest.raises(ValueError, match="Unknown automatic profile"):
+        preprocessing_tools.estimate_automatic_rgb_ranges(
+            tmp_path,
+            ["section_1"],
+            source_channels=["green"],
+            target_profiles={"green": "unknown"},
+        )

--- a/test/test_gui_stack_compatibility.py
+++ b/test/test_gui_stack_compatibility.py
@@ -106,15 +106,100 @@ def test_sharpy_cy3_default_matches_direct_stitching():
 def test_disabled_rgb_contrast_does_not_parse_limit_fields():
     preprocessing_widget = preprocessing.PreprocessingWidget()
     rgb_widget = preprocessing_widget.rgb_widget
-    rgb_widget[3].value = False
+    rgb_widget["contrast_mode"].value = "none"
 
-    for contrast_widget in rgb_widget[4:]:
-        contrast_widget.value = ""
+    for channel in ("cy3", "green"):
+        rgb_widget[f"{channel}_row"][
+            f"{channel}_manual_range"
+        ].value = ""
 
     rgb_params = preprocessing_widget._get_widget_info(rgb_widget, "rgb")
 
+    assert rgb_params["contrast_mode"] == "none"
     assert rgb_params["contrast_adjustment"] is False
     assert rgb_params["green"] == []
     assert rgb_params["cy3"] == []
+
+    preprocessing_widget.close()
+
+
+def test_rgb_manual_mode_preserves_existing_defaults():
+    preprocessing_widget = preprocessing.PreprocessingWidget()
+
+    rgb_params = preprocessing_widget._get_rgb_widget_info()
+
+    assert rgb_params == {
+        "channels": ["cy3", "green"],
+        "downsampling": 3,
+        "contrast_mode": "manual",
+        "contrast_adjustment": True,
+        "cy3": [50, 2000],
+        "green": [50, 1000],
+    }
+
+    preprocessing_widget.close()
+
+
+def test_unselected_rgb_channel_disables_automatic_profile():
+    preprocessing_widget = preprocessing.PreprocessingWidget()
+    rgb_widget = preprocessing_widget.rgb_widget
+    rgb_widget["contrast_mode"].value = "automatic"
+    green_row = rgb_widget["green_row"]
+    green_row["green_profile"].value = "preserve_strong_signal_probe"
+    green_row["green_enabled"].value = False
+
+    rgb_params = preprocessing_widget._get_rgb_widget_info()
+
+    assert green_row["green_profile"].enabled is False
+    assert green_row["green_estimated_range"].value == "Not selected"
+    assert rgb_params["channels"] == ["cy3"]
+    assert rgb_params["automatic_profiles"] == {
+        "cy3": "preserve_strong_signal_probe"
+    }
+
+    green_row["green_enabled"].value = True
+    assert green_row["green_profile"].enabled is True
+    assert (
+        green_row["green_profile"].value
+        == "preserve_strong_signal_probe"
+    )
+
+    preprocessing_widget.close()
+
+
+def test_rgb_estimation_progress_prints_section_cutoffs(capsys):
+    preprocessing_widget = preprocessing.PreprocessingWidget()
+    rgb_widget = preprocessing_widget.rgb_widget
+    rgb_widget["contrast_mode"].value = "automatic"
+    calibration_key = preprocessing_widget._current_rgb_calibration_key()
+
+    preprocessing_widget._update_rgb_estimation_progress(
+        (
+            calibration_key,
+            {
+                "event": "section",
+                "section_index": 2,
+                "total_sections": 5,
+                "image_name": "section_002",
+                "status": "processed",
+                "padding_fraction": 0.125,
+                "channel_cutoffs": {
+                    "cy3": [50, 60000],
+                    "green": [100, 900],
+                },
+            },
+        )
+    )
+
+    assert rgb_widget["estimation_progress"].value == 2
+    assert rgb_widget["estimate_ranges"].text == "Estimating 2/5..."
+    output = capsys.readouterr().out
+    assert "[Automatic RGB contrast] [2/5] section_002" in output
+    assert "cy3=50–60000" in output
+    assert "green=100–900" in output
+    assert "padding excluded=12.50%" in output
+    assert all(
+        widget.name != "estimation_report" for widget in rgb_widget
+    )
 
     preprocessing_widget.close()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -97,6 +97,43 @@ def test_update_params_dict(tmp_path):
         assert json.load(f) == new_params
 
 
+def test_update_params_dict_can_replace_nested_section(tmp_path):
+    input_path = tmp_path / "animal_id"
+    input_path.mkdir()
+    existing_params = {
+        "general": {"animal_id": "animal_id", "group": "control"},
+        "rgb_params": {
+            "contrast_mode": "automatic",
+            "green": [100, 900],
+            "automatic_ranges": {"green": [100, 900]},
+            "automatic_profiles": {"green": "balanced_cells"},
+        },
+    }
+    with open(input_path / "params.json", "w") as f:
+        json.dump(existing_params, f)
+
+    manual_params = {
+        "general": {"animal_id": "animal_id"},
+        "rgb_params": {
+            "channels": ["green"],
+            "contrast_mode": "manual",
+            "contrast_adjustment": True,
+            "downsampling": 3,
+            "green": [50, 1000],
+        },
+    }
+    updated = update_params_dict(
+        input_path,
+        manual_params,
+        replace_sections=("rgb_params",),
+    )
+
+    assert updated["general"]["group"] == "control"
+    assert updated["rgb_params"] == manual_params["rgb_params"]
+    assert "automatic_ranges" not in updated["rgb_params"]
+    assert "automatic_profiles" not in updated["rgb_params"]
+
+
 
 
 def test_split_to_list():


### PR DESCRIPTION
# Add automatic dataset-wide RGB contrast calibration

## Summary

This PR adds optional dataset-wide automatic contrast calibration for RGB preprocessing while preserving the existing manual workflow as the default.

It introduces per-channel profiles suitable for cell fluorescence and strong Neuropixels probe signals, excludes artificial black padding, and applies one consistent contrast range per channel across the dataset.

## Changes

- Add three RGB contrast modes:
  - `Manual`
  - `Automatic`
  - `None`
- Add independent RGB channel selection.
- Add two automatic profiles:
  - `Balanced (cells)`
  - `Preserve strong signal (probe)`
- Default Cy3 to the probe profile.
- Default green and DAPI to the cell profile.
- Disable profile selection and exclude calibration when a channel is unchecked.
- Preserve a channel’s selected profile when it is re-enabled.
- Add an `Estimate ranges` action.
- Show estimation progress using:
  - a current-section/total progress bar;
  - changing `Estimating current/total...` button text;
  - detailed per-section cutoff and padding information in the terminal.
- Automatically estimate ranges during preprocessing when no valid preview is cached.
- Persist resolved ranges and calibration metadata in `params.json`.
- Preserve channel order during preprocessing.

## Automatic calibration

The calibration computes one fixed contrast range per selected channel for the complete dataset.

### Shared behavior

- Uses exact 65,536-bin histograms for uint8 and uint16 images.
- Gives every eligible section equal weight.
- Excludes rectangular outer black padding.
- Determines image content bounds using all declared imaged source channels.
- Keeps internal zero-valued pixels inside the content bounds.
- Does not estimate or require a tissue mask.
- Keeps the final intensity mapping linear.

### Balanced (cells)

Designed for fluorescence with signal intensities relatively close to the background.

- Clips 0.175% from the low histogram tail.
- Clips 0.175% from the high histogram tail.

### Preserve strong signal (probe)

Designed for bright probe tracts that may appear in relatively few sections.

- Clips 0.175% from the low histogram tail.
- Calculates each section’s 99.99th-percentile high cutoff.
- Uses the dataset’s 99th percentile of those section-level high cutoffs.

This prevents rare, strongly fluorescent sections from being lost in a pooled dataset histogram.

## Progress reporting

During automatic estimation, the terminal reports:

- current section and total section count;
- section filename;
- provisional low/high cutoff for each selected channel;
- excluded black-padding percentage;
- skipped all-black sections;
- final dataset-wide ranges;
- calibration errors.

Example:

```text
[Automatic RGB contrast] [2/50] section_002: cy3=50–60000, green=100–900; padding excluded=12.50%