### PR TITLE
Standardize atlas hemisphere and orientation conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Standardized public mediolateral coordinates as positive in the anatomical
+  left hemisphere and negative in the anatomical right hemisphere.
+- Corrected the brain-section hemisphere tooltip and coordinate displays, and
+  added compatibility normalization for historical left-negative result CSVs.
+- Documented the relationship between atlas RL indices, all section
+  orientations, 3D voxel exports, and signed ML coordinates.
+- Removed Allen-10-um-specific hemisphere slicing from injection-site coverage
+  and corrected atlas-plane extraction for horizontal and sagittal sections.
+
 ## 0.2.0b1 - 2026-08-11
 
 This is a beta release of the next DMC-BrainMap feature series. It contains

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ Plugins > dmc_brainmap
 
 ### Usage
 
+#### Coordinate convention
+
+DMC-BrainMap uses a left-positive mediolateral convention in result CSV files
+and user-facing analysis: `ML > 0` is anatomical left and `ML < 0` is
+anatomical right. In an unflipped coronal BrainGlobe atlas image, anatomical
+left appears on image-right because the atlas `rl` index increases from right
+to left. See the
+[coordinate and hemisphere conventions](https://napari-dmc-brainmap.readthedocs.io/en/latest/coordinate_conventions.html)
+for result-file compatibility and mirroring details.
+
 Please refer to the Wiki pages for detailed instructions and a short tutorial on how to use DMC-BrainMap. When working with DMC-BrainMap on your own data, please keep the following points in mind:
 - DMC-BrainMap requires single-channel 16-bit .tif/.tiff images to work (in principle 8-bit also work)
 - DMC-BrainMap requires that your data is organized by animals in separate folders (you can pool data later down the lane)

--- a/docs/source/coordinate_conventions.rst
+++ b/docs/source/coordinate_conventions.rst
@@ -1,0 +1,65 @@
+Coordinate and hemisphere conventions
+=====================================
+
+DMC-BrainMap reports public mediolateral coordinates with a left-positive
+sign convention:
+
+* ``ml_mm > 0`` is the anatomical left hemisphere.
+* ``ml_mm < 0`` is the anatomical right hemisphere.
+* ``ml_mm == 0`` is the midline.
+
+For BrainGlobe atlases whose right-to-left axis is named ``rl``, atlas indices
+increase from anatomical right to anatomical left. Therefore:
+
+* ``ml_coords > bregma_rl`` is the anatomical left hemisphere.
+* ``ml_coords < bregma_rl`` is the anatomical right hemisphere.
+
+An unflipped coronal atlas image consequently displays anatomical left on the
+right side of the image and anatomical right on the left side. Image pixels
+must not be assigned a hemisphere from screen left or screen right after an
+image has been mirrored, rotated, or exported; use the registered atlas
+coordinate instead.
+
+Section orientations
+--------------------
+
+The hemisphere rule is independent of section orientation. For the standard
+BrainGlobe ASR axis order ``(ap, si, rl)``, DMC-BrainMap maps atlas sections as
+follows:
+
+* coronal: ``(x, y, slice) = (rl, si, ap)``;
+* horizontal: ``(x, y, slice) = (rl, ap, si)``;
+* sagittal: ``(x, y, slice) = (si, ap, rl)``.
+
+The RL coordinate is therefore an in-plane horizontal coordinate in standard
+coronal and horizontal plots. In a sagittal view, RL selects the slice: a
+positive ML value selects a slice in the anatomical left hemisphere rather
+than a left-hand region within the displayed plane. A viewer may transpose or
+rotate a plane, so screen direction must not be used as the hemisphere label.
+
+Voxel coordinates and 3D rendering
+----------------------------------
+
+Atlas voxel coordinates are absolute, origin-based indices. The optional
+brainrender export writes these coordinates in atlas axis order and scales
+them to micrometres. It does not write bregma-relative ``ap_mm``, ``dv_mm``,
+and ``ml_mm`` values. A point whose ``ml_coords`` is greater than
+``bregma_rl`` therefore remains in the anatomical left hemisphere in the 3D
+atlas, but a signed ``ml_mm`` value must not be passed directly as an atlas
+world coordinate.
+
+The apparent left and right sides of a rotatable 3D view also depend on camera
+position and display handedness. This can make a correctly located point look
+mirrored without changing its underlying anatomical hemisphere.
+
+Result-file compatibility
+-------------------------
+
+Current result CSV files and user-facing coordinate displays use left-positive
+``ml_mm`` values. Older result CSV files may contain axis-native values in
+which anatomical left is negative. The visualization data loader derives
+``ml_mm`` from ``ml_coords``, atlas bregma, and atlas resolution, so both old
+and current result files are interpreted using the public left-positive
+convention. ``coord_mm_transform`` remains a low-level index-oriented utility
+for registration calculations and should not be used by itself to assign a
+hemisphere.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,4 +12,5 @@ napari-dmc-brainmap documentation
    :caption: Contents:
 
    registration_prediction
+   coordinate_conventions
    modules

--- a/src/napari_dmc_brainmap/deprecated/probe_visualizer/probe_vis/probe_vis/view/MainWidget.py
+++ b/src/napari_dmc_brainmap/deprecated/probe_visualizer/probe_vis/probe_vis/view/MainWidget.py
@@ -57,7 +57,11 @@ class MainWidget():
             # rotate AP axis to screen width axis
             self.slice = probeV.template[:, :, probeV.currentML].T.copy()
             cv2.putText(self.slice, "ML: "+str(probeV.currentML), (10,text_h+10), cv2.FONT_HERSHEY_SIMPLEX, 1, 255, 3, cv2.LINE_AA)
-            cv2.putText(self.slice, "("+str(np.round((probeV.bregma[2] -probeV.currentML) * self.resolution[2],probeV.decimal))+" mm)" , 
+            ml_mm = np.round(
+                (probeV.currentML - probeV.bregma[2]) * self.resolution[2],
+                probeV.decimal,
+            )
+            cv2.putText(self.slice, "("+str(ml_mm)+" mm)" ,
                         (10,text_h*2+20), cv2.FONT_HERSHEY_SIMPLEX, 1, 255, 3, cv2.LINE_AA) # mm coordinate
         
         # add active probe to slice

--- a/src/napari_dmc_brainmap/deprecated/probe_visualizer/probe_vis/probe_vis/view/ProbeVisualizer.py
+++ b/src/napari_dmc_brainmap/deprecated/probe_visualizer/probe_vis/probe_vis/view/ProbeVisualizer.py
@@ -257,7 +257,7 @@ class ProbeVisualizer(QMainWindow):
                          (self.atlas.resolution[self.atlas.space.axes_description.index('ap')]/1000),self.decimal)
         dv_mm = np.round((self.bregma[1] - vox_dv) *
                          (self.atlas.resolution[self.atlas.space.axes_description.index('si')] / 1000), self.decimal)
-        ml_mm = np.round((self.bregma[2] - vox_ml) *
+        ml_mm = np.round((vox_ml - self.bregma[2]) *
                          (self.atlas.resolution[self.atlas.space.axes_description.index('rl')] / 1000), self.decimal)
         return [ap_mm,dv_mm,ml_mm]
 

--- a/src/napari_dmc_brainmap/deprecated/results/find_structure.py
+++ b/src/napari_dmc_brainmap/deprecated/results/find_structure.py
@@ -6,6 +6,7 @@ from natsort import natsorted
 from tifffile import tifffile
 from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.model.calculation import fitGeoTrans, mapPointTransform
 from napari_dmc_brainmap.utils import get_bregma, xyz_atlas_transform, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import atlas_mm_to_analysis_mm
 import numpy as np
 import json
 from bg_atlasapi import BrainGlobeAtlas
@@ -152,6 +153,10 @@ class sliceHandle():
                     acronym_list.append('root')
                 # calculate Allen coordinates in mm unit
                 vol_mm = coord_mm_transform(triplet, self.bregma, self.atlas.space.resolution)
+                vol_mm = atlas_mm_to_analysis_mm(
+                    vol_mm,
+                    self.atlas.space.axes_description,
+                )
                 vol_mm_list.append(vol_mm)
             name_dict = {
                 'ap': 'ap',
@@ -169,7 +174,6 @@ class sliceHandle():
                                         columns=col_names)
             section_data['section_name'] = [section_name] * len(section_data)
             return section_data
-
 
 
 

--- a/src/napari_dmc_brainmap/deprecated/results/tract_calculation.py
+++ b/src/napari_dmc_brainmap/deprecated/results/tract_calculation.py
@@ -4,6 +4,9 @@ import distinctipy
 import matplotlib.pyplot as plt
 from skspatial.objects import Line, Points # scikit-spatial package: https://scikit-spatial.readthedocs.io/en/stable/
 from napari_dmc_brainmap.utils import get_animal_id, get_info, get_bregma, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_ml_from_atlas_coordinate,
+)
 
 def get_primary_axis_idx(direction_vector): # get primary axis from direction vector
     direction_comp = np.abs(direction_vector) # get component absolute value
@@ -238,6 +241,12 @@ def get_probe_tract(input_path, atlas, seg_type, ax_primary, probe_df, probe, pr
                                                                     row[col_names[1]],
                                                                     row[col_names[2]]],
                                                                    bregma, atlas.space.resolution)), axis=1)
+    rl_idx = atlas.space.axes_description.index('rl')
+    probe_tract['ml_mm'] = analysis_ml_from_atlas_coordinate(
+        probe_tract['ml_coords'].to_numpy(),
+        bregma[rl_idx],
+        atlas.space.resolution[rl_idx],
+    )
 
     probe_tract['structure_id'] = annot[probe_tract[col_names[0]], probe_tract[col_names[1]], probe_tract[col_names[2]]]
 

--- a/src/napari_dmc_brainmap/deprecated/visualization/visualization_tools.py
+++ b/src/napari_dmc_brainmap/deprecated/visualization/visualization_tools.py
@@ -16,13 +16,16 @@ from shapely.geometry import LineString
 import matplotlib.cm as cm
 from natsort import natsorted
 from napari_dmc_brainmap.utils import get_info, get_bregma, get_xyz, find_key_by_value
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_ml_from_atlas_coordinate,
+)
 from napari_dmc_brainmap.visualization.visualization_utils import match_lists, get_descendants
 
 
 def get_ipsi_contra(df):
     '''
     Function to add a column specifying if cells if ipsi or contralateral to injection site
-    ml_mm values of <0 are on the 'left' hemisphere, >0 are on the 'right hemisphere
+    Positive ml_mm values are left and negative values are right.
     :param df: dataframe with results for animal, not the merged across animals
     :return:
     '''
@@ -112,7 +115,12 @@ def load_data(input_path, atlas, animal_list, channels, data_type='cells', hemis
                 results_data = pd.read_csv(results_file)  # load the data
                 if data_type in ["optic_fiber", "neuropixels_probe"]:
                     results_data = results_data[results_data['inside_brain']]
-                results_data['ml_mm'] *= (-1)  # so that negative values are left hemisphere
+                rl_idx = atlas.space.axes_description.index('rl')
+                results_data['ml_mm'] = analysis_ml_from_atlas_coordinate(
+                    results_data['ml_coords'].to_numpy(),
+                    get_bregma(atlas.atlas_name)[rl_idx],
+                    atlas.space.resolution[rl_idx],
+                )
                 results_data['animal_id'] = [animal_id] * len(
                     results_data)  # add the animal_id as a column for later identification
                 if (data_type == "optic_fiber" or data_type == "neuropixels_probe") and len(animal_list) > 1:
@@ -609,4 +617,3 @@ def get_heatmap_mask(heatmap_data, annot_section_plt):
     mask = mask1 | mask2
 
     return mask
-

--- a/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/model/AtlasModel.py
+++ b/src/napari_dmc_brainmap/registration/sharpy_track/sharpy_track/model/AtlasModel.py
@@ -11,7 +11,14 @@ from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.model.prediction
     homography_to_registration_points,
 )
 # from napari_dmc_brainmap.preprocessing.preprocessing_tools import adjust_contrast, do_8bit
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, xyz_atlas_transform, coord_mm_transform, sort_ap_dv_ml
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_mm_from_atlas_axis_mm,
+    atlas_mm_to_analysis_mm,
+    coord_mm_transform,
+    get_bregma,
+    sort_ap_dv_ml,
+    xyz_atlas_transform,
+)
 from napari_dmc_brainmap.utils.atlas_cache import load_template_8bit
 
 from importlib.resources import files
@@ -115,6 +122,10 @@ class AtlasModel():
         # get coordinates in mm
         tripled_coord = xyz_atlas_transform([x, y, z], self.regi_dict, self.atlas.space.axes_description)
         tripled_mm = coord_mm_transform(tripled_coord, self.bregma, self.atlas.space.resolution)
+        tripled_mm = atlas_mm_to_analysis_mm(
+            tripled_mm,
+            self.atlas.space.axes_description,
+        )
 
         tripled_mm_sorted = sort_ap_dv_ml(tripled_mm, self.atlas.space.axes_description)
         # from cursor position get annotation index
@@ -141,12 +152,16 @@ class AtlasModel():
             'rl': 'ML'
         }
         z_str = name_dict[self.xyz_dict['z'][0]]
+        z_mm = analysis_mm_from_atlas_axis_mm(
+            self.regViewer.status.current_z,
+            self.xyz_dict['z'][0],
+        )
         x_str = name_dict[self.xyz_dict['x'][0]]
         y_str = name_dict[self.xyz_dict['y'][0]]
         # get textbox size and calculate textbox coordinates
         offset =  int(self.fontscale * 10) # integer
 
-        text_w, text_h = cv2.getTextSize(z_str + ": " + str(self.regViewer.status.current_z)+"mm", cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, self.fontthickness)[0]
+        text_w, text_h = cv2.getTextSize(z_str + ": " + str(z_mm)+"mm", cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, self.fontthickness)[0]
         ap_text_location = [display_slice.shape[1]-offset-text_w,text_h+offset]
 
         text_w, text_h = cv2.getTextSize(x_str + " Angle: " + str(self.regViewer.status.x_angle), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, self.fontthickness)[0]
@@ -155,7 +170,7 @@ class AtlasModel():
         text_w, text_h = cv2.getTextSize(y_str + " Angle: " + str(self.regViewer.status.y_angle), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, self.fontthickness)[0]
         yangle_text_location = [offset,offset+text_h+offset+text_h]
         # put text
-        cv2.putText(display_slice, z_str + ": " + str(self.regViewer.status.current_z)+"mm", (ap_text_location[0], ap_text_location[1]), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, 255, self.fontthickness, cv2.LINE_AA)
+        cv2.putText(display_slice, z_str + ": " + str(z_mm)+"mm", (ap_text_location[0], ap_text_location[1]), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, 255, self.fontthickness, cv2.LINE_AA)
         cv2.putText(display_slice, x_str + " Angle: " + str(self.regViewer.status.x_angle), (xangle_text_location[0], xangle_text_location[1]), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, 255, self.fontthickness, cv2.LINE_AA)
         cv2.putText(display_slice, y_str + " Angle: " + str(self.regViewer.status.y_angle), (yangle_text_location[0],yangle_text_location[1]), cv2.FONT_HERSHEY_SIMPLEX, self.fontscale, 255, self.fontthickness, cv2.LINE_AA)
 

--- a/src/napari_dmc_brainmap/results/probe_vis/probe_vis/view/MainWidget.py
+++ b/src/napari_dmc_brainmap/results/probe_vis/probe_vis/view/MainWidget.py
@@ -60,7 +60,11 @@ class MainWidget():
             # rotate AP axis to screen width axis
             self.slice = probeV.template[:, :, probeV.currentML].T.copy()
             cv2.putText(self.slice, "ML: "+str(probeV.currentML), (10,text_h+10), cv2.FONT_HERSHEY_SIMPLEX, 1, 255, 3, cv2.LINE_AA)
-            cv2.putText(self.slice, "("+str(np.round((probeV.bregma[2] -probeV.currentML) * self.resolution[2],probeV.decimal))+" mm)" , 
+            ml_mm = np.round(
+                (probeV.currentML - probeV.bregma[2]) * self.resolution[2],
+                probeV.decimal,
+            )
+            cv2.putText(self.slice, "("+str(ml_mm)+" mm)",
                         (10,text_h*2+20), cv2.FONT_HERSHEY_SIMPLEX, 1, 255, 3, cv2.LINE_AA) # mm coordinate
         
         # add active probe to slice

--- a/src/napari_dmc_brainmap/results/probe_vis/probe_vis/view/ProbeVisualizer.py
+++ b/src/napari_dmc_brainmap/results/probe_vis/probe_vis/view/ProbeVisualizer.py
@@ -2,7 +2,10 @@ from qtpy.QtGui import QAction
 from qtpy.QtWidgets import QMainWindow, QMenu, QFileDialog, QApplication
 from napari_dmc_brainmap.results.probe_vis.probe_vis.view.MainWidget import MainWidget
 # from napari_dmc_brainmap.preprocessing.preprocessing_tools import adjust_contrast, do_8bit
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_ml_from_atlas_coordinate,
+    get_bregma,
+)
 from napari_dmc_brainmap.utils.atlas_cache import load_template_8bit
 
 import numpy as np
@@ -232,8 +235,12 @@ class ProbeVisualizer(QMainWindow):
                          (self.atlas.resolution[self.atlas.space.axes_description.index('ap')]/1000),self.decimal)
         dv_mm = np.round((self.bregma[1] - vox_dv) *
                          (self.atlas.resolution[self.atlas.space.axes_description.index('si')] / 1000), self.decimal)
-        ml_mm = np.round((self.bregma[2] - vox_ml) *
-                         (self.atlas.resolution[self.atlas.space.axes_description.index('rl')] / 1000), self.decimal)
+        rl_idx = self.atlas.space.axes_description.index('rl')
+        ml_mm = analysis_ml_from_atlas_coordinate(
+            vox_ml,
+            self.bregma[2],
+            self.atlas.resolution[rl_idx],
+        )
         return [ap_mm,dv_mm,ml_mm]
 
     def createMenus(self):

--- a/src/napari_dmc_brainmap/results/results.py
+++ b/src/napari_dmc_brainmap/results/results.py
@@ -23,7 +23,10 @@ from napari_dmc_brainmap.utils.dataframe_utils import clip_negative_first_row
 from napari_dmc_brainmap.utils.path_utils import get_info
 from napari_dmc_brainmap.utils.general_utils import split_to_list
 from napari_dmc_brainmap.utils.params_utils import load_params
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import (
+    get_axis_mm_limits,
+    get_bregma,
+)
 from napari_dmc_brainmap.utils.gui_utils import ProgressBar, check_input_path
 from napari_dmc_brainmap.utils.data_loader import DataLoader
 from napari_dmc_brainmap.results.probe_vis.probe_vis.view.ProbeVisualizer import ProbeVisualizer
@@ -497,8 +500,13 @@ class ResultsWidget(QWidget):
                 axis_idx = self.atlas.space.sections.index(x_key[2])
                 axis_dim = self.atlas.shape[axis_idx]
 
-                xmin = coord_mm_transform([axis_dim], [bregma[axis_idx]], [self.atlas.resolution[axis_idx]])
-                xmax = coord_mm_transform([0], [bregma[axis_idx]], [self.atlas.resolution[axis_idx]])
+                axis_name = self.atlas.space.axes_description[axis_idx]
+                xmin, xmax = get_axis_mm_limits(
+                    axis_name,
+                    axis_dim,
+                    bregma[axis_idx],
+                    self.atlas.resolution[axis_idx],
+                )
                 xticks = np.linspace(xmin, xmax, 5)
 
                 static_ax[1].set_xlim([xmin, xmax])
@@ -518,14 +526,24 @@ class ResultsWidget(QWidget):
 
                 x_axis_idx = self.atlas.space.sections.index(x_key[2])
                 x_axis_dim = self.atlas.shape[x_axis_idx]
-                xmin = coord_mm_transform([x_axis_dim], [bregma[x_axis_idx]], [self.atlas.resolution[x_axis_idx]])
-                xmax = coord_mm_transform([0], [bregma[x_axis_idx]], [self.atlas.resolution[x_axis_idx]])
+                x_axis_name = self.atlas.space.axes_description[x_axis_idx]
+                xmin, xmax = get_axis_mm_limits(
+                    x_axis_name,
+                    x_axis_dim,
+                    bregma[x_axis_idx],
+                    self.atlas.resolution[x_axis_idx],
+                )
                 xticks = np.linspace(xmin, xmax, 5)
 
                 y_axis_idx = self.atlas.space.sections.index(y_key[2])
                 y_axis_dim = self.atlas.shape[y_axis_idx]
-                ymin = coord_mm_transform([y_axis_dim], [bregma[y_axis_idx]], [self.atlas.resolution[y_axis_idx]])
-                ymax = coord_mm_transform([0], [bregma[y_axis_idx]], [self.atlas.resolution[y_axis_idx]])
+                y_axis_name = self.atlas.space.axes_description[y_axis_idx]
+                ymin, ymax = get_axis_mm_limits(
+                    y_axis_name,
+                    y_axis_dim,
+                    bregma[y_axis_idx],
+                    self.atlas.resolution[y_axis_idx],
+                )
                 yticks = np.linspace(ymin, ymax, 5)
 
                 if expression:

--- a/src/napari_dmc_brainmap/results/results_helpers/results_quantifier.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/results_quantifier.py
@@ -8,7 +8,12 @@ from napari.utils.notifications import show_info
 from napari_dmc_brainmap.utils.path_utils import get_info
 from napari_dmc_brainmap.utils.general_utils import split_strings_layers, get_animal_id
 from napari_dmc_brainmap.utils.data_loader import DataLoader
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma
+from napari_dmc_brainmap.utils.atlas_utils import (
+    get_bregma,
+    get_xyz,
+    hemisphere_from_atlas_coordinate,
+)
+from napari_dmc_brainmap.utils.params_utils import load_params
 
 class ResultsQuantifier:
     """
@@ -205,7 +210,6 @@ class ResultsQuantifier:
         return animal_data
 
     def _calculate_injection_site_coverage(self, quant_df_pivot_raw):
-        # todo hemispheres
         fn_plane_data = self.results_dir.joinpath(f'{get_animal_id(self.input_path)}_{self.seg_type}_plane_data.npz')
         plane_data = np.load(fn_plane_data)
         section_list = self.results_data['section_name'].unique().tolist()
@@ -218,21 +222,40 @@ class ResultsQuantifier:
         )
         region_count = {v: 0 for v in id_to_parent_map.values()}
 
-        # todo work in progress - injection sites need to be on one hemisphere alone
         bregma = get_bregma(self.atlas.atlas_name)
-        if len(self.results_data[self.results_data['ml_coords'] >= bregma[2]]) >= \
-                len(self.results_data[self.results_data['ml_coords'] < bregma[2]]):
-            larger_bregma = True
-        else:
-            larger_bregma = False
+        rl_idx = self.atlas.space.axes_description.index('rl')
+        bregma_rl = bregma[rl_idx]
+        injection_hemisphere = self._majority_hemisphere(
+            self.results_data['ml_coords'].to_numpy(),
+            bregma_rl,
+        )
+        orientation = load_params(self.input_path)['atlas_info']['orientation']
+        xyz_dict = get_xyz(self.atlas, orientation)
+        rl_axis = next(
+            axis for axis in ('x', 'y', 'z')
+            if xyz_dict[axis][0] == 'rl'
+        )
 
         for section in section_list:
             try:
                 p_d = plane_data[section[:-len(ds_suffix)]]
-                if larger_bregma:
-                    p_d = p_d[:,570:]
+                if rl_axis == 'z':
+                    section_data = self.results_data.loc[
+                        self.results_data['section_name'] == section,
+                        'ml_coords',
+                    ]
+                    if section_data.empty or self._majority_hemisphere(
+                        section_data.to_numpy(),
+                        bregma_rl,
+                    ) != injection_hemisphere:
+                        continue
                 else:
-                    p_d = p_d[:,:570]
+                    p_d = self._crop_plane_to_hemisphere(
+                        p_d,
+                        rl_axis,
+                        bregma_rl,
+                        injection_hemisphere,
+                    )
 
                 for k, v in id_to_parent_map.items():
                     region_count[v] += int(np.sum(p_d == k))
@@ -248,6 +271,44 @@ class ResultsQuantifier:
                 show_info(f'Error for calculating 2D estimate!')
 
         return quant_df_inj_coverage
+
+    @staticmethod
+    def _majority_hemisphere(ml_coords, bregma_rl):
+        """Return the dominant anatomical hemisphere for atlas RL indices."""
+        hemispheres = hemisphere_from_atlas_coordinate(
+            np.asarray(ml_coords),
+            bregma_rl,
+        )
+        left_count = np.count_nonzero(
+            (hemispheres == 'left') | (hemispheres == 'midline')
+        )
+        right_count = np.count_nonzero(hemispheres == 'right')
+        return 'left' if left_count >= right_count else 'right'
+
+    @staticmethod
+    def _crop_plane_to_hemisphere(
+        plane,
+        rl_axis,
+        bregma_rl,
+        hemisphere,
+    ):
+        """Crop an atlas plane along its in-plane RL axis."""
+        if rl_axis not in ('x', 'y'):
+            raise ValueError("The in-plane RL axis must be 'x' or 'y'.")
+        if hemisphere not in ('left', 'right'):
+            raise ValueError("Hemisphere must be 'left' or 'right'.")
+
+        if rl_axis == 'x':
+            return (
+                plane[:, bregma_rl:]
+                if hemisphere == 'left'
+                else plane[:, :bregma_rl]
+            )
+        return (
+            plane[bregma_rl:, :]
+            if hemisphere == 'left'
+            else plane[:bregma_rl, :]
+        )
     # def _plot_quant_data(self, df):
     #
     #     clrs = sns.color_palette(self.plotting_params["cmap"])

--- a/src/napari_dmc_brainmap/results/results_helpers/slice_handle.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/slice_handle.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from napari.utils.notifications import show_info
 from napari_dmc_brainmap.registration.sharpy_track.sharpy_track.model.calculation import fitGeoTrans, mapPointTransform
 from napari_dmc_brainmap.utils.general_utils import get_animal_id
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, xyz_atlas_transform, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import (
+    atlas_mm_to_analysis_mm,
+    coord_mm_transform,
+    get_bregma,
+    xyz_atlas_transform,
+)
 from brainglobe_atlasapi import BrainGlobeAtlas
 
 class SliceHandle():
@@ -227,6 +232,10 @@ class SliceHandle():
                     acronym_list.append('root')
                 # calculate Allen coordinates in mm unit
                 vol_mm = coord_mm_transform(triplet, self.bregma, self.atlas.space.resolution)
+                vol_mm = atlas_mm_to_analysis_mm(
+                    vol_mm,
+                    self.atlas.space.axes_description,
+                )
                 vol_mm_list.append(vol_mm)
             name_dict = {
                 'ap': 'ap',
@@ -250,15 +259,19 @@ class SliceHandle():
         Function to get atlas plane data for respective registered image
         :return: np.array: containing atlas plane data
         """
-        z_plane = self.get_z_plane(str(self.currentSlice))
-        z_flat = z_plane.astype(int).ravel()
+        z_plane = self.get_z_plane(str(self.currentSlice)).astype(np.intp)
         x_max = self.regi_dict['xyz_dict']['x'][1]
         y_max = self.regi_dict['xyz_dict']['y'][1]
         y = np.arange(y_max)
         x = np.arange(x_max)
         grid_x, grid_y = np.meshgrid(x, y)
-        r_grid_x = grid_x.ravel()
-        r_grid_y = grid_y.ravel()
-        sliceAnnot = self.annot[z_flat, r_grid_y, r_grid_x].reshape(self.regi_dict['xyz_dict']['y'][1],
-                                                                         self.regi_dict['xyz_dict']['x'][1]).astype(np.int32)
-        return sliceAnnot
+        section_coordinates = {
+            self.regi_dict['xyz_dict']['x'][0]: grid_x,
+            self.regi_dict['xyz_dict']['y'][0]: grid_y,
+            self.regi_dict['xyz_dict']['z'][0]: z_plane,
+        }
+        atlas_indices = tuple(
+            section_coordinates[axis]
+            for axis in self.atlas.space.axes_description
+        )
+        return self.annot[atlas_indices].astype(np.int32)

--- a/src/napari_dmc_brainmap/results/results_helpers/tract_calculator.py
+++ b/src/napari_dmc_brainmap/results/results_helpers/tract_calculator.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from napari.utils.notifications import show_info
 from napari_dmc_brainmap.utils.path_utils import get_info
 from napari_dmc_brainmap.utils.general_utils import get_animal_id
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_ml_from_atlas_coordinate,
+    coord_mm_transform,
+    get_bregma,
+)
 from napari_dmc_brainmap.results.results_helpers.slice_handle import SliceHandle
 
 class TractCalculator:
@@ -362,6 +366,12 @@ class TractCalculator:
                                                                         row[col_names[1]],
                                                                         row[col_names[2]]],
                                                                        bregma, self.atlas.space.resolution)), axis=1)
+        rl_idx = self.atlas.space.axes_description.index('rl')
+        probe_tract['ml_mm'] = analysis_ml_from_atlas_coordinate(
+            probe_tract['ml_coords'].to_numpy(),
+            bregma[rl_idx],
+            self.atlas.space.resolution[rl_idx],
+        )
 
         probe_tract['structure_id'] = self.annot[
             probe_tract[col_names[0]], probe_tract[col_names[1]], probe_tract[col_names[2]]]

--- a/src/napari_dmc_brainmap/utils/atlas_utils.py
+++ b/src/napari_dmc_brainmap/utils/atlas_utils.py
@@ -92,6 +92,97 @@ def coord_mm_transform(triplet: List[Union[int, float]], bregma: List[int], reso
         return triplet_new
 
 
+def analysis_ml_from_atlas_coordinate(
+        ml_coordinate: Union[int, float, np.ndarray],
+        bregma_rl: Union[int, float],
+        resolution_um: float
+) -> Union[float, np.ndarray]:
+    """Convert atlas RL indices to the public left-positive ML convention.
+
+    BrainGlobe's ``rl`` index increases from anatomical right to left. DMC-
+    BrainMap therefore reports ``ml_mm`` as positive in the left hemisphere,
+    negative in the right hemisphere, and zero at the midline.
+    """
+    decimal = get_decimal([resolution_um])[0]
+    converted = np.round(
+        (np.asarray(ml_coordinate, dtype=float) - bregma_rl)
+        * (resolution_um / 1000),
+        decimal,
+    )
+    if converted.ndim == 0:
+        return float(converted)
+    return converted
+
+
+def atlas_mm_to_analysis_mm(
+        triplet: List[Union[int, float]],
+        atlas_tuple: Tuple[str, str, str]
+) -> List[float]:
+    """Convert axis-native atlas millimeters to public analysis coordinates.
+
+    ``coord_mm_transform`` follows atlas index direction for every axis, so its
+    RL value is negative on the anatomical left. Public results and displays
+    use the opposite ML sign. AP and DV values are unchanged.
+    """
+    triplet_new = list(triplet)
+    rl_idx = atlas_tuple.index('rl')
+    triplet_new[rl_idx] = -triplet_new[rl_idx]
+    if triplet_new[rl_idx] == 0:
+        triplet_new[rl_idx] = 0.0
+    return triplet_new
+
+
+def analysis_mm_from_atlas_axis_mm(
+        coordinate: Union[int, float, np.ndarray],
+        axis: str
+) -> Union[float, np.ndarray]:
+    """Convert one axis-native millimetre value to public coordinates."""
+    converted = np.asarray(coordinate, dtype=float)
+    if axis == 'rl':
+        converted = -converted
+    if converted.ndim == 0:
+        value = float(converted)
+        return 0.0 if value == 0 else value
+    converted[converted == 0] = 0.0
+    return converted
+
+
+def hemisphere_from_atlas_coordinate(
+        ml_coordinate: Union[int, float, np.ndarray],
+        bregma_rl: Union[int, float]
+) -> Union[str, np.ndarray]:
+    """Return anatomical hemisphere labels from atlas RL indices."""
+    coordinates = np.asarray(ml_coordinate)
+    hemispheres = np.full(coordinates.shape, 'midline', dtype=object)
+    hemispheres[coordinates > bregma_rl] = 'left'
+    hemispheres[coordinates < bregma_rl] = 'right'
+    if hemispheres.ndim == 0:
+        return str(hemispheres.item())
+    return hemispheres
+
+
+def get_axis_mm_limits(
+        axis: str,
+        axis_size: int,
+        bregma_coordinate: Union[int, float],
+        resolution_um: float
+) -> Tuple[float, float]:
+    """Return increasing public-coordinate limits for an atlas axis."""
+    if axis == 'rl':
+        endpoints = analysis_ml_from_atlas_coordinate(
+            np.asarray([0, axis_size]),
+            bregma_coordinate,
+            resolution_um,
+        )
+    else:
+        endpoints = coord_mm_transform(
+            [0, axis_size],
+            [bregma_coordinate, bregma_coordinate],
+            [resolution_um, resolution_um],
+        )
+    return float(np.min(endpoints)), float(np.max(endpoints))
+
+
 def sort_ap_dv_ml(triplet: List[Union[int, float]], atlas_tuple: Tuple[str, str, str]) -> List[float]:
     """
     Reorder the input triplet to match the atlas orientation.

--- a/src/napari_dmc_brainmap/utils/data_loader.py
+++ b/src/napari_dmc_brainmap/utils/data_loader.py
@@ -4,7 +4,12 @@ from typing import List, Union
 import pandas as pd
 from natsort import natsorted
 from napari_dmc_brainmap.utils.path_utils import get_info
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, coord_mm_transform
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_ml_from_atlas_coordinate,
+    coord_mm_transform,
+    get_bregma,
+    hemisphere_from_atlas_coordinate,
+)
 from brainglobe_atlasapi import BrainGlobeAtlas
 from napari.utils.notifications import show_info
 
@@ -60,7 +65,7 @@ class DataLoader:
                     continue
                 if self.data_type in ["optic_fiber", "neuropixels_probe"]:
                     results_data = results_data.loc[results_data['inside_brain']].copy()
-                results_data['ml_mm'] *= -1  # Convert negative values for the left hemisphere
+                results_data = self._normalize_ml_mm(results_data)
                 results_data['animal_id'] = animal_id
                 results_data['channel'] = f"{animal_id}_{channel}" if (
                         self.data_type in ["optic_fiber", "neuropixels_probe"] and len(self.animal_list) > 1) else channel
@@ -179,6 +184,28 @@ class DataLoader:
 
         return pd.read_csv(results_file)
 
+    def _normalize_ml_mm(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return data using positive-left public ML coordinates.
+
+        Historical result files store axis-native ML values (left negative),
+        while current result files store public analysis values (left
+        positive). Rebuilding ML from atlas voxel coordinates makes both file
+        generations load identically.
+        """
+        normalized = df.copy()
+        if 'ml_coords' in normalized.columns:
+            rl_idx = self.atlas.space.axes_description.index('rl')
+            normalized['ml_mm'] = analysis_ml_from_atlas_coordinate(
+                normalized['ml_coords'].to_numpy(),
+                self.bregma[rl_idx],
+                self.atlas.space.resolution[rl_idx],
+            )
+        else:
+            # Compatibility fallback for legacy external tables without atlas
+            # voxel columns; these historically used left-negative ML values.
+            normalized['ml_mm'] *= -1
+        return normalized
+
     def _load_swc_data(self, animal_id: str, channel: str) -> Union[pd.DataFrame, None]:
         """
         Load swc data for a specific channel of an animal.
@@ -210,6 +237,12 @@ class DataLoader:
         coords = swc_merge[["ap_coords", "dv_coords", "ml_coords"]].to_numpy()
         mm_coords = [coord_mm_transform(row, self.bregma, self.atlas.space.resolution) for row in coords]
         swc_merge[["ap_mm", "dv_mm", "ml_mm"]] = pd.DataFrame(mm_coords, index=swc_merge.index)
+        rl_idx = self.atlas.space.axes_description.index('rl')
+        swc_merge['ml_mm'] = analysis_ml_from_atlas_coordinate(
+            swc_merge['ml_coords'].to_numpy(),
+            self.bregma[rl_idx],
+            self.atlas.space.resolution[rl_idx],
+        )
         return swc_merge
 
     def _get_ipsi_contra(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -229,10 +262,21 @@ class DataLoader:
         injection_site = df['injection_site'].iloc[0]
         df['ipsi_contra'] = 'ipsi'
 
+        if 'ml_coords' in df.columns:
+            rl_idx = self.atlas.space.axes_description.index('rl')
+            hemispheres = hemisphere_from_atlas_coordinate(
+                df['ml_coords'].to_numpy(),
+                self.bregma[rl_idx],
+            )
+        else:
+            hemispheres = pd.Series('midline', index=df.index, dtype=object)
+            hemispheres.loc[df['ml_mm'] > 0] = 'left'
+            hemispheres.loc[df['ml_mm'] < 0] = 'right'
+
         if injection_site == 'left':
-            df.loc[df['ml_mm'] < 0, 'ipsi_contra'] = 'contra'
+            df.loc[hemispheres == 'right', 'ipsi_contra'] = 'contra'
         elif injection_site == 'right':
-            df.loc[df['ml_mm'] > 0, 'ipsi_contra'] = 'contra'
+            df.loc[hemispheres == 'left', 'ipsi_contra'] = 'contra'
         else:
             raise ValueError(f"Unexpected value in 'injection_site': {injection_site}. Expected 'left' or 'right'.")
 

--- a/src/napari_dmc_brainmap/visualization/vis_plots/brainsection_plotter.py
+++ b/src/napari_dmc_brainmap/visualization/vis_plots/brainsection_plotter.py
@@ -8,7 +8,11 @@ from sklearn.preprocessing import MinMaxScaler
 from skimage.transform import resize
 from scipy.ndimage import gaussian_filter
 from scipy.spatial.distance import cdist
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma, get_xyz
+from napari_dmc_brainmap.utils.atlas_utils import (
+    get_bregma,
+    get_xyz,
+    hemisphere_from_atlas_coordinate,
+)
 from napari_dmc_brainmap.visualization.vis_utils.visualization_utils import get_descendants, match_lists
 from brainglobe_atlasapi import BrainGlobeAtlas
 from napari.utils.notifications import show_info
@@ -44,7 +48,8 @@ class BrainsectionPlotter:
 
         Parameters:
             slice_idx (int): Index of the brain slice.
-            orient_idx (int): Orientation index (0: coronal, 1: sagittal, 2: horizontal).
+            orient_idx (int): BrainGlobe section index (0: coronal,
+                1: horizontal, 2: sagittal).
 
         Returns:
             List: Annotated section, unique IDs, and color dictionary.
@@ -96,7 +101,8 @@ class BrainsectionPlotter:
 
         Parameters:
             slice_idx (int): Index of the brain slice.
-            orient_idx (int): Orientation index (0: coronal, 1: sagittal, 2: horizontal).
+            orient_idx (int): BrainGlobe section index (0: coronal,
+                1: horizontal, 2: sagittal).
 
         Returns:
             np.ndarray: Extracted slice from the atlas.
@@ -114,7 +120,8 @@ class BrainsectionPlotter:
 
         Parameters:
             annot_section (np.ndarray): Annotated section.
-            orient_idx (int): Orientation index (0: coronal, 1: sagittal, 2: horizontal).
+            orient_idx (int): BrainGlobe section index (0: coronal,
+                1: horizontal, 2: sagittal).
 
         Returns:
             np.ndarray: Adjusted annotated section.
@@ -245,8 +252,17 @@ class BrainsectionPlotter:
         Returns:
             Tuple[List[str], List[str]]: Sorted brain areas and corresponding colors.
         """
-        df = self.data_dict[self.plotting_params['area_density']].assign(
-            left_right=np.where(self.data_dict[self.plotting_params['area_density']]['ml_mm'] < 0, 'right', 'left'))
+        source = self.data_dict[self.plotting_params['area_density']]
+        rl_idx = self.atlas.space.axes_description.index('rl')
+        hemispheres = hemisphere_from_atlas_coordinate(
+            source['ml_coords'].to_numpy(),
+            get_bregma(self.atlas.atlas_name)[rl_idx],
+        )
+        # Preserve the historical density behavior that includes exact
+        # midline points with the left half instead of creating a third side.
+        df = source.assign(
+            left_right=np.where(hemispheres == 'right', 'right', 'left')
+        )
         animal_list = df['animal_id'].unique()
         df_density = self._calculate_density_pivot(df, animal_list)
         df_density = self._normalize_density(df_density)
@@ -556,9 +572,6 @@ class BrainsectionPlotter:
         mask = mask1 | mask2
 
         return mask
-
-
-
 
 
 

--- a/src/napari_dmc_brainmap/visualization/visualization.py
+++ b/src/napari_dmc_brainmap/visualization/visualization.py
@@ -470,7 +470,7 @@ def initialize_brainsection_widget() -> FunctionGui:
                               label='plotting hemisphere',
                               choices=['both', 'left', 'right'],
                               value='both',
-                              tooltip="choose to either plot both hemisphere, or left (ML<0 mm)/right (ML > 0 mm) "
+                              tooltip="choose to either plot both hemispheres, or left (ML > 0 mm)/right (ML < 0 mm) "
                                       "hemisphere (only for coronal/horizontal orientations)"),
               brain_areas=dict(widget_type='LineEdit', 
                                label='list of brain areas',

--- a/test/test_gui_stack_compatibility.py
+++ b/test/test_gui_stack_compatibility.py
@@ -81,6 +81,9 @@ def test_representative_widget_defaults_are_preserved(monkeypatch):
     assert visualization_widget.save_fig.value is False
     assert visualization_widget.section_orient.value == "coronal"
     assert visualization_widget.hemisphere.value == "both"
+    assert "left (ML > 0 mm)/right (ML < 0 mm)" in (
+        visualization_widget.unilateral.tooltip
+    )
 
     params_widget.native.close()
     segment_widget.native.close()

--- a/test/test_pandas_copy_semantics.py
+++ b/test/test_pandas_copy_semantics.py
@@ -83,12 +83,20 @@ def test_inside_brain_filter_does_not_warn_or_mutate_loaded_data(
         {
             "inside_brain": [True, False],
             "ml_mm": [1.0, 2.0],
+            "ml_coords": [400, 300],
         }
     )
 
     loader = object.__new__(DataLoader)
     loader.input_path = tmp_path
-    loader.atlas = SimpleNamespace(metadata={"name": "custom_atlas"})
+    loader.atlas = SimpleNamespace(
+        metadata={"name": "custom_atlas"},
+        space=SimpleNamespace(
+            axes_description=("ap", "si", "rl"),
+            resolution=(10.0, 10.0, 10.0),
+        ),
+    )
+    loader.bregma = [0, 0, 500]
     loader.animal_list = ["animal-1"]
     loader.channels = ["probe"]
     loader.data_type = "neuropixels_probe"
@@ -106,9 +114,52 @@ def test_inside_brain_filter_does_not_warn_or_mutate_loaded_data(
     assert source.to_dict("list") == {
         "inside_brain": [True, False],
         "ml_mm": [1.0, 2.0],
+        "ml_coords": [400, 300],
     }
     assert result["ml_mm"].tolist() == [-1.0]
     assert result["ipsi_contra"].tolist() == ["ipsi"]
+
+
+def test_ml_normalization_accepts_legacy_and_current_result_signs():
+    loader = object.__new__(DataLoader)
+    loader.atlas = SimpleNamespace(
+        space=SimpleNamespace(
+            axes_description=("ap", "si", "rl"),
+            resolution=(10.0, 10.0, 10.0),
+        )
+    )
+    loader.bregma = [0, 0, 570]
+    source = pd.DataFrame(
+        {
+            "ml_coords": [730, 410],
+            # First is legacy left-negative; second is current right-negative.
+            "ml_mm": [-1.6, -1.6],
+        }
+    )
+
+    result = loader._normalize_ml_mm(source)
+
+    assert source["ml_mm"].tolist() == [-1.6, -1.6]
+    assert result["ml_mm"].tolist() == [1.6, -1.6]
+
+
+def test_ipsi_contra_uses_atlas_hemisphere_not_input_ml_sign():
+    loader = object.__new__(DataLoader)
+    loader.atlas = SimpleNamespace(
+        space=SimpleNamespace(axes_description=("ap", "si", "rl"))
+    )
+    loader.bregma = [0, 0, 570]
+    source = pd.DataFrame(
+        {
+            "ml_coords": [730, 410],
+            "ml_mm": [-99.0, 99.0],
+            "injection_site": ["left", "left"],
+        }
+    )
+
+    result = loader._get_ipsi_contra(source)
+
+    assert result["ipsi_contra"].tolist() == ["ipsi", "contra"]
 
 
 def test_heatmap_binning_accepts_a_filtered_frame_without_warning():
@@ -212,7 +263,10 @@ def test_swc_loader_accepts_mixed_whitespace_without_future_warning(
     loader.data_type = "swc"
     loader.bregma = [0, 0, 0]
     loader.atlas = SimpleNamespace(
-        space=SimpleNamespace(resolution=[1, 1, 1])
+        space=SimpleNamespace(
+            axes_description=("ap", "si", "rl"),
+            resolution=[1, 1, 1],
+        )
     )
     monkeypatch.setattr(
         "napari_dmc_brainmap.utils.data_loader.get_info",
@@ -242,6 +296,7 @@ def test_swc_loader_accepts_mixed_whitespace_without_future_warning(
     }
     assert result["neuron_id"].tolist() == ["neuron", "neuron"]
     assert result["group_id"].tolist() == ["control", "control"]
+    assert result["ml_mm"].tolist() == [0.01, 0.011]
 
 
 def test_heatmap_pivot_preserves_unobserved_bins():

--- a/test/test_probe_visualizer.py
+++ b/test/test_probe_visualizer.py
@@ -23,3 +23,18 @@ def test_organize_probe_keeps_coordinates_signed():
     assert visualizer.probe_list[0].dtype == np.intp
     np.testing.assert_array_equal(visualizer.probe_list[0], [[0, -1, 2]])
     assert visualizer.probe_axis == [0]
+
+
+def test_probe_visualizer_reports_left_positive_ml():
+    visualizer = SimpleNamespace(
+        bregma=[540, 0, 570],
+        decimal=2,
+        atlas=SimpleNamespace(
+            resolution=(10.0, 10.0, 10.0),
+            space=SimpleNamespace(axes_description=("ap", "si", "rl")),
+        ),
+    )
+
+    coordinates = ProbeVisualizer.getCoordMM(visualizer, [540, 0, 730])
+
+    assert coordinates == [0.0, 0.0, 1.6]

--- a/test/test_results_quantifier.py
+++ b/test/test_results_quantifier.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from napari_dmc_brainmap.results.results_helpers.results_quantifier import (
+    ResultsQuantifier,
+)
+
+
+def test_majority_hemisphere_uses_left_positive_atlas_direction():
+    assert ResultsQuantifier._majority_hemisphere(
+        np.array([571, 600, 500]),
+        570,
+    ) == 'left'
+    assert ResultsQuantifier._majority_hemisphere(
+        np.array([500, 520, 600]),
+        570,
+    ) == 'right'
+
+
+@pytest.mark.parametrize(
+    ("rl_axis", "hemisphere", "expected"),
+    [
+        ("x", "left", np.arange(24).reshape(4, 6)[:, 3:]),
+        ("x", "right", np.arange(24).reshape(4, 6)[:, :3]),
+        ("y", "left", np.arange(24).reshape(4, 6)[2:, :]),
+        ("y", "right", np.arange(24).reshape(4, 6)[:2, :]),
+    ],
+)
+def test_crop_plane_to_hemisphere_uses_rl_axis(
+    rl_axis,
+    hemisphere,
+    expected,
+):
+    plane = np.arange(24).reshape(4, 6)
+    bregma_rl = 3 if rl_axis == "x" else 2
+
+    result = ResultsQuantifier._crop_plane_to_hemisphere(
+        plane,
+        rl_axis,
+        bregma_rl,
+        hemisphere,
+    )
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_crop_plane_to_hemisphere_rejects_slice_axis():
+    with pytest.raises(ValueError, match="in-plane RL axis"):
+        ResultsQuantifier._crop_plane_to_hemisphere(
+            np.zeros((2, 2)),
+            "z",
+            1,
+            "left",
+        )

--- a/test/test_slice_handle.py
+++ b/test/test_slice_handle.py
@@ -39,3 +39,89 @@ def test_get_z_plane_rejects_slice_outside_atlas_volume():
 
     with pytest.raises(ValueError, match="outside volume bounds"):
         handle.get_z_plane("0")
+
+
+def test_result_coordinates_report_left_positive_ml():
+    handle = SliceHandle.__new__(SliceHandle)
+    handle.currentSlice = 0
+    handle.regi_dict = {
+        "xyz_dict": {
+            "x": ("ap", 1),
+            "y": ("si", 1),
+            "z": ("rl", 1),
+        }
+    }
+    handle.bregma = [540, 0, 570]
+    handle.atlas = SimpleNamespace(
+        space=SimpleNamespace(
+            axes_description=("ap", "si", "rl"),
+            resolution=(10.0, 10.0, 10.0),
+        ),
+        structure_from_coords=lambda _coords: 1,
+    )
+    handle.sTree = SimpleNamespace(
+        data={1: {"name": "region", "acronym": "REG"}}
+    )
+    handle.getVolumeIndex = lambda _slice, _coords: [[540, 0, 730]]
+
+    result = handle.getBrainArea([(0, 0)], "section")
+
+    assert result.loc[0, "ml_coords"] == 730
+    assert result.loc[0, "ml_mm"] == 1.6
+
+
+@pytest.mark.parametrize(
+    ("xyz_dict", "slice_idx", "expected"),
+    [
+        (
+            {
+                "x": ("rl", 4),
+                "y": ("si", 3),
+                "z": ("ap", 2),
+            },
+            1,
+            lambda annotation: annotation[1, :, :],
+        ),
+        (
+            {
+                "x": ("rl", 4),
+                "y": ("ap", 2),
+                "z": ("si", 3),
+            },
+            1,
+            lambda annotation: annotation[:, 1, :],
+        ),
+        (
+            {
+                "x": ("si", 3),
+                "y": ("ap", 2),
+                "z": ("rl", 4),
+            },
+            1,
+            lambda annotation: annotation[:, :, 1],
+        ),
+    ],
+    ids=("coronal", "horizontal", "sagittal"),
+)
+def test_get_atlas_plane_respects_section_orientation(
+    xyz_dict,
+    slice_idx,
+    expected,
+):
+    handle = SliceHandle.__new__(SliceHandle)
+    handle.currentSlice = 0
+    handle.regi_dict = {"xyz_dict": xyz_dict}
+    handle.atlas = SimpleNamespace(
+        space=SimpleNamespace(axes_description=("ap", "si", "rl"))
+    )
+    handle.annot = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+    plane_shape = (xyz_dict["y"][1], xyz_dict["x"][1])
+    handle.get_z_plane = lambda _slice: np.full(
+        plane_shape,
+        slice_idx,
+        dtype=np.intp,
+    )
+
+    plane = handle.getAtlasPlane()
+
+    np.testing.assert_array_equal(plane, expected(handle.annot))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,7 +6,14 @@ from napari_dmc_brainmap.utils.atlas_utils import get_decimal
 from napari_dmc_brainmap.utils.atlas_utils import coord_mm_transform
 from napari_dmc_brainmap.utils.atlas_utils import sort_ap_dv_ml
 from napari_dmc_brainmap.utils.atlas_utils import get_xyz
-from napari_dmc_brainmap.utils.atlas_utils import get_bregma
+from napari_dmc_brainmap.utils.atlas_utils import (
+    analysis_mm_from_atlas_axis_mm,
+    analysis_ml_from_atlas_coordinate,
+    atlas_mm_to_analysis_mm,
+    get_bregma,
+    get_axis_mm_limits,
+    hemisphere_from_atlas_coordinate,
+)
 
 from napari_dmc_brainmap.utils.general_utils import get_animal_id
 from napari_dmc_brainmap.utils.general_utils import split_to_list
@@ -18,6 +25,7 @@ from napari_dmc_brainmap.utils.params_utils import clean_params_dict
 from napari_dmc_brainmap.utils.params_utils import update_params_dict
 
 import pathlib
+import numpy as np
 import pytest
 from unittest.mock import patch
 import json
@@ -307,6 +315,38 @@ def test_coord_mm_transform():
     assert coord_mm_transform(triplet, bregma, resolution_tuple, mm_to_coord) == expected_output
 
 
+def test_analysis_ml_convention_is_positive_in_atlas_left_hemisphere():
+    converted = analysis_ml_from_atlas_coordinate(
+        np.array([410, 570, 730]),
+        bregma_rl=570,
+        resolution_um=10,
+    )
+
+    np.testing.assert_array_equal(converted, [-1.6, 0.0, 1.6])
+    assert hemisphere_from_atlas_coordinate(730, 570) == 'left'
+    assert hemisphere_from_atlas_coordinate(570, 570) == 'midline'
+    assert hemisphere_from_atlas_coordinate(410, 570) == 'right'
+
+
+def test_axis_limits_use_public_ml_sign_for_asymmetric_atlas():
+    assert get_axis_mm_limits('rl', 1000, 400, 10.0) == (-4.0, 6.0)
+    assert get_axis_mm_limits('ap', 1000, 400, 10.0) == (-6.0, 4.0)
+
+
+def test_axis_native_mm_conversion_only_flips_rl():
+    assert analysis_mm_from_atlas_axis_mm(-1.6, 'rl') == 1.6
+    assert analysis_mm_from_atlas_axis_mm(1.6, 'ap') == 1.6
+
+
+def test_axis_native_ml_is_flipped_for_public_analysis_coordinates():
+    converted = atlas_mm_to_analysis_mm(
+        [2.8, -2.03, -1.6],
+        ('ap', 'si', 'rl'),
+    )
+
+    assert converted == [2.8, -2.03, 1.6]
+
+
 def test_sort_ap_dv_ml():
     # Test case 1: atlas_tuple matches target tuple order
     triplet = [1.1, 2.2, 3.3]
@@ -327,15 +367,15 @@ def test_get_xyz():
     atlas_instance = atlas_mock.return_value
     atlas_instance.space.sections = ['frontal', 'horizontal', 'sagittal']
     atlas_instance.space.index_pairs = [(1, 2), (0, 2), (0, 1)]
-    atlas_instance.space.axes_description = ['ap', 'dv', 'ml']
+    atlas_instance.space.axes_description = ['ap', 'si', 'rl']
     atlas_instance.space.shape = [1320, 800, 1140]
     atlas_instance.space.resolution = [10.0, 10.0, 10.0]
 
     # Test case 1: coronal section
     section_orient = 'coronal'
     expected_output = {
-        'x': ['ml', 1140, 10.0],
-        'y': ['dv', 800, 10.0],
+        'x': ['rl', 1140, 10.0],
+        'y': ['si', 800, 10.0],
         'z': ['ap', 1320, 10.0]
     }
     assert get_xyz(atlas_instance, section_orient) == expected_output
@@ -343,18 +383,18 @@ def test_get_xyz():
     # Test case 2: horizontal section
     section_orient = 'horizontal'
     expected_output = {
-        'x': ['ml', 1140, 10.0],
+        'x': ['rl', 1140, 10.0],
         'y': ['ap', 1320, 10.0],
-        'z': ['dv', 800, 10.0]
+        'z': ['si', 800, 10.0]
     }
     assert get_xyz(atlas_instance, section_orient) == expected_output
 
     # Test case 3: sagittal section
     section_orient = 'sagittal'
     expected_output = {
-        'x': ['dv', 800, 10.0],
+        'x': ['si', 800, 10.0],
         'y': ['ap', 1320, 10.0],
-        'z': ['ml', 1140, 10.0]
+        'z': ['rl', 1140, 10.0]
     }
     assert get_xyz(atlas_instance, section_orient) == expected_output
     # Stop the patch


### PR DESCRIPTION
## Summary

Standardize DMC-BrainMap’s public mediolateral coordinate convention:

- `ML > 0` represents the anatomical left hemisphere
- `ML < 0` represents the anatomical right hemisphere
- `ML = 0` represents the midline

This follows BrainGlobe’s standard ASR atlas orientation, where the RL index increases from anatomical right toward anatomical left.

## Changes

- Added shared helpers for converting native atlas RL coordinates into positive-left analysis coordinates.
- Updated result CSV and probe-tract generation to write positive-left `ml_mm`.
- Normalized historical result CSVs from their authoritative `ml_coords`, preserving compatibility with existing datasets.
- Updated ipsilateral/contralateral assignment to use atlas coordinates instead of potentially ambiguous stored ML signs.
- Corrected ML displays in registration and probe visualization.
- Corrected hemisphere labels and density calculations.
- Corrected atlas-plane extraction for coronal, horizontal, and sagittal orientations.
- Removed the hard-coded Allen 10 µm midline from injection-site coverage.
- Corrected plot limits for asymmetric atlases.
- Preserved native atlas coordinates for brainrender and other 3D exports.
- Added coordinate-convention documentation and updated the README and changelog.
- Audited active and deprecated source code for stale orientation assumptions.

## Compatibility

Historical result files remain compatible inside DMC-BrainMap because `ml_mm` is reconstructed from `ml_coords`, atlas bregma, and resolution when data is loaded.

This intentionally changes the meaning of `ml_mm` in newly generated raw CSV files. External scripts that previously assumed anatomical left was negative must adopt the new positive-left convention or derive ML using:

```python
ml_mm = (ml_coords - bregma_rl) * (resolution_um / 1000)