### PR TITLE
Show workflow-specific controls in the segmentation widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Simplified the segmentation widget by showing only controls and
+  presegmentation sections relevant to the selected workflow. RGB annotation
+  now offers DAPI, green, and Cy3; N3 and Cy5 are available in single-channel
+  mode.
 - Standardized public mediolateral coordinates as positive in the anatomical
   left hemisphere and negative in the anatomical right hemisphere.
 - Corrected the brain-section hemisphere tooltip and coordinate displays, and

--- a/src/napari_dmc_brainmap/segment/segment.py
+++ b/src/napari_dmc_brainmap/segment/segment.py
@@ -23,6 +23,16 @@ from napari_dmc_brainmap.segment.processing.presegmentation_tools import Project
 from napari_dmc_brainmap.segment.processing.centroid_finder import CentroidFinder
 
 
+RGB_CHANNELS = ('dapi', 'green', 'cy3')
+SINGLE_CHANNELS = ('dapi', 'green', 'n3', 'cy3', 'cy5')
+TRACT_SEGMENTATION_TYPES = ('optic_fiber', 'neuropixels_probe')
+POINT_SEGMENTATION_TYPES = (
+    'cells',
+    'optic_fiber',
+    'neuropixels_probe',
+    'projections',
+)
+
 
 def get_cmap(name: str) -> Dict[str, str]:
     """
@@ -180,10 +190,10 @@ def initialize_segment_widget() -> FunctionGui:
                               tooltip='directory of folder containing subfolders with e.g. images, segmentation results, NOT '
                                       'folder containing segmentation results'),
               single_channel_bool=dict(widget_type='CheckBox',
-                                       text='use single channel',
+                                       text='use single-channel images for annotation',
                                        value=False,
-                                       tooltip='tick to use single channel images (not RGB), one can still select '
-                                               'multiple channels'),
+                                       tooltip='tick to annotate separate single-channel images instead of an RGB image; '
+                                               'N3 and Cy5 are available only in this mode'),
               seg_type=dict(widget_type='ComboBox',
                             label='segmentation type',
                             choices=['cells', 'injection_site', 'optic_fiber', 'neuropixels_probe', 'projections'],
@@ -203,7 +213,7 @@ def initialize_segment_widget() -> FunctionGui:
               channels=dict(widget_type='Select',
                             label='selected channels',
                             value=['green', 'cy3'],
-                            choices=['dapi', 'green', 'n3', 'cy3', 'cy5'],
+                            choices=RGB_CHANNELS,
                             tooltip='select channels to be used for segmentation, '
                                     'to select multiple hold ctrl/shift'),
               contrast_dapi=dict(widget_type='LineEdit',
@@ -235,16 +245,17 @@ def initialize_segment_widget() -> FunctionGui:
             viewer: Viewer,
             input_path,  # posix path
             seg_type,
-            n_probes,
-            point_size,
+            single_channel_bool,
             channels,
             contrast_dapi,
             contrast_green,
             contrast_n3,
             contrast_cy3,
             contrast_cy5,
+            n_probes,
+            point_size,
             image_idx,
-            single_channel_bool):
+    ):
         pass
 
     return segment_widget
@@ -290,10 +301,10 @@ def initialize_presegcells_widget():
     """
     @magicgui(layout='vertical',
               single_channel_bool=dict(widget_type='CheckBox',
-                                       text='use single channel',
+                                       text='use single-channel images for cell presegmentation',
                                        value=False,
-                                       tooltip='tick to use single channel images (not RGB), one can still select '
-                                               'multiple channels'),
+                                       tooltip='tick to run cell presegmentation on separate single-channel images '
+                                               'instead of RGB images'),
               regi_bool=dict(widget_type='CheckBox',
                              text='registration done?',
                              value=True,
@@ -521,6 +532,65 @@ class SegmentWidget(QWidget):
         self.layout().addWidget(self._collapse_centroid)
         self.layout().addWidget(self.btn)
 
+        self.segment.seg_type.changed.connect(self._update_segmentation_ui)
+        self.segment.single_channel_bool.changed.connect(
+            self._update_channel_options
+        )
+        self.segment.channels.changed.connect(
+            self._update_contrast_visibility
+        )
+        self._update_channel_options()
+        self._update_segmentation_ui()
+
+    def _update_segmentation_ui(self, *_args) -> None:
+        """Show only controls relevant to the selected segmentation type."""
+        seg_type = self.segment.seg_type.value
+        self.segment.n_probes.visible = seg_type in TRACT_SEGMENTATION_TYPES
+        self.segment.point_size.visible = seg_type in POINT_SEGMENTATION_TYPES
+
+        cells_selected = seg_type == 'cells'
+        self._collapse_cells.setVisible(cells_selected)
+        self._collapse_centroid.setVisible(cells_selected)
+        self._collapse_projections.setVisible(seg_type == 'projections')
+
+    def _update_channel_options(self, *_args) -> None:
+        """Limit RGB annotation to channels represented by the RGB image."""
+        channels_widget = self.segment.channels
+        selected_channels = list(channels_widget.value)
+        allowed_channels = (
+            SINGLE_CHANNELS
+            if self.segment.single_channel_bool.value
+            else RGB_CHANNELS
+        )
+
+        if tuple(channels_widget.choices) != allowed_channels:
+            # Clearing first preserves the intended order when choices that
+            # were previously removed are restored by magicgui.
+            channels_widget.choices = []
+            channels_widget.choices = allowed_channels
+
+        valid_selection = [
+            channel
+            for channel in selected_channels
+            if channel in allowed_channels
+        ]
+        if not valid_selection:
+            valid_selection = [
+                channel
+                for channel in ('green', 'cy3')
+                if channel in allowed_channels
+            ]
+        channels_widget.value = valid_selection
+        self._update_contrast_visibility()
+
+    def _update_contrast_visibility(self, *_args) -> None:
+        """Show contrast limits only for channels selected for annotation."""
+        selected_channels = set(self.segment.channels.value)
+        for channel in SINGLE_CHANNELS:
+            self.segment[f'contrast_{channel}'].visible = (
+                channel in selected_channels
+            )
+
     def _default_save_dict(self) -> Dict[str, Union[bool, int]]:
         """
         Create a default save dictionary for storing segmentation data.
@@ -553,23 +623,28 @@ class SegmentWidget(QWidget):
         self.save_dict['n_probes'] = n_probes
         return self.save_dict
 
-    def _get_contrast_dict(self, widget: FunctionGui) -> Dict[str, List[int]]:
+    def _get_contrast_dict(
+        self,
+        widget: FunctionGui,
+        channels: List[str],
+    ) -> Dict[str, List[int]]:
         """
         Retrieve contrast settings for each channel from the widget.
 
         Parameters:
             widget (FunctionGui): The widget containing contrast settings.
+            channels (List[str]): Selected annotation channels.
 
         Returns:
             Dict[str, List[int]]: A dictionary of contrast limits for each channel.
         """
 
         return {
-            "dapi": [int(i) for i in widget.contrast_dapi.value.split(',')],
-            "green": [int(i) for i in widget.contrast_green.value.split(',')],
-            "n3": [int(i) for i in widget.contrast_n3.value.split(',')],
-            "cy3": [int(i) for i in widget.contrast_cy3.value.split(',')],
-            "cy5": [int(i) for i in widget.contrast_cy5.value.split(',')]
+            channel: [
+                int(value)
+                for value in widget[f'contrast_{channel}'].value.split(',')
+            ]
+            for channel in channels
         }
 
     def _save_and_load(self) -> None:
@@ -587,9 +662,13 @@ class SegmentWidget(QWidget):
         image_idx = int(self.segment.image_idx.value)
         seg_type = self.segment.seg_type.value
         channels = self.segment.channels.value
-        n_probes = int(self.segment.n_probes.value)
+        n_probes = (
+            int(self.segment.n_probes.value)
+            if seg_type in TRACT_SEGMENTATION_TYPES
+            else 1
+        )
         single_channel = self.segment.single_channel_bool.value
-        contrast_dict = self._get_contrast_dict(self.segment)
+        contrast_dict = self._get_contrast_dict(self.segment, channels)
 
         if len(self.viewer.layers) == 0:  # no open images, set save_dict to defaults
             self.save_dict = self._default_save_dict()

--- a/test/test_gui_stack_compatibility.py
+++ b/test/test_gui_stack_compatibility.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -104,6 +105,99 @@ def test_sharpy_cy3_default_matches_direct_stitching():
 
     preprocessing_widget.close()
     stitching_widget.native.close()
+
+
+@pytest.mark.parametrize(
+    (
+        "seg_type",
+        "show_probe_count",
+        "show_point_size",
+        "show_cells",
+        "show_centroids",
+        "show_projections",
+    ),
+    [
+        ("cells", False, True, True, True, False),
+        ("injection_site", False, False, False, False, False),
+        ("optic_fiber", True, True, False, False, False),
+        ("neuropixels_probe", True, True, False, False, False),
+        ("projections", False, True, False, False, True),
+    ],
+)
+def test_segmentation_type_shows_only_relevant_controls(
+    seg_type,
+    show_probe_count,
+    show_point_size,
+    show_cells,
+    show_centroids,
+    show_projections,
+):
+    widget = segment.SegmentWidget(SimpleNamespace())
+
+    widget.segment.seg_type.value = seg_type
+
+    assert widget.segment.n_probes.native.isHidden() is not show_probe_count
+    assert widget.segment.point_size.native.isHidden() is not show_point_size
+    assert widget._collapse_cells.isHidden() is not show_cells
+    assert widget._collapse_centroid.isHidden() is not show_centroids
+    assert widget._collapse_projections.isHidden() is not show_projections
+    assert widget._collapse_load_preseg.isHidden() is False
+
+    widget.close()
+
+
+def test_segmentation_annotation_channels_follow_image_mode():
+    widget = segment.SegmentWidget(SimpleNamespace())
+    channels = widget.segment.channels
+
+    assert [child.name for child in widget.segment][1:5] == [
+        "input_path",
+        "seg_type",
+        "single_channel_bool",
+        "channels",
+    ]
+    assert tuple(channels.choices) == ("dapi", "green", "cy3")
+    assert channels.value == ["green", "cy3"]
+    assert widget.segment.contrast_dapi.native.isHidden() is True
+    assert widget.segment.contrast_green.native.isHidden() is False
+    assert widget.segment.contrast_cy3.native.isHidden() is False
+    assert widget.segment.contrast_n3.native.isHidden() is True
+    assert widget.segment.contrast_cy5.native.isHidden() is True
+
+    widget.segment.single_channel_bool.value = True
+    assert tuple(channels.choices) == (
+        "dapi",
+        "green",
+        "n3",
+        "cy3",
+        "cy5",
+    )
+
+    channels.value = ["green", "n3"]
+    assert widget.segment.contrast_green.native.isHidden() is False
+    assert widget.segment.contrast_n3.native.isHidden() is False
+    assert widget.segment.contrast_cy3.native.isHidden() is True
+
+    widget.segment.single_channel_bool.value = False
+    assert tuple(channels.choices) == ("dapi", "green", "cy3")
+    assert channels.value == ["green"]
+    assert widget.segment.contrast_n3.native.isHidden() is True
+
+    widget.close()
+
+
+def test_hidden_contrast_fields_are_not_parsed():
+    widget = segment.SegmentWidget(SimpleNamespace())
+    widget.segment.contrast_n3.value = ""
+    widget.segment.contrast_cy5.value = "not,a,range"
+
+    contrast = widget._get_contrast_dict(
+        widget.segment,
+        widget.segment.channels.value,
+    )
+
+    assert contrast == {"green": [0, 100], "cy3": [0, 100]}
+    widget.close()
 
 
 def test_disabled_rgb_contrast_does_not_parse_limit_fields():


### PR DESCRIPTION
## Summary

Simplify the Segmentation widget by showing only controls and presegmentation sections relevant to the selected segmentation workflow.

This reduces visual clutter and provides a cleaner foundation for adding a dedicated Neuropixels 2.0 four-shank workflow later. Four-shank reconstruction and curation are not included in this PR.

## Changes

- Dynamically update the widget when the segmentation type changes.
- Show the number of fibers/probes only for:
  - optic-fiber segmentation
  - Neuropixels-probe segmentation
- Hide point size for injection-site segmentation, which uses polygons rather than points.
- Show cell presegmentation and centroid extraction only for cell segmentation.
- Show projection presegmentation only for projection segmentation.
- Keep loading old or presegmented data available to all workflows.
- Reorder the shared controls so image path, segmentation type, annotation image mode, and channels appear first.

## Channel handling

- Limit RGB annotation to channels represented by the RGB image:
  - DAPI
  - green
  - Cy3
- Make N3 and Cy5 available only when single-channel annotation is enabled.
- Show contrast controls only for currently selected channels.
- Ignore hidden and unselected contrast fields during parameter parsing.
- Preserve valid channel selections when switching image modes.
- Fall back to green and Cy3 if switching to RGB removes every selected channel.

## Label clarification

Rename the two previously identical `use single channel` checkboxes to clarify their independent scopes:

- `Use single-channel images for annotation`
- `Use single-channel images for cell presegmentation`

The first controls images loaded for manual annotation. The second controls input to the automatic cell-presegmentation pipeline.

## Compatibility

Existing segmentation processing and output formats are unchanged.

The cleanup preserves the current single-shank Neuropixels workflow. It also provides an appropriate extension point for future Neuropixels-specific controls without exposing those controls in unrelated segmentation workflows.

## Validation

- Focused GUI and segmentation tests: **43 passed**
- Full test suite: **255 passed**
- Python compilation: passed
- `git diff --check`: passed

The test coverage includes:

- visibility behavior for all five segmentation types;
- RGB and single-channel mode transitions;
- channel-choice filtering;
- contrast-field visibility;
- ignoring hidden contrast values;
- shared-control ordering.